### PR TITLE
fix: pin angular2-dependencies-graph version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/compodoc/compodoc#readme",
   "dependencies": {
-    "angular2-dependencies-graph": "^1.0.0-alpha.12",
+    "angular2-dependencies-graph": "1.0.0-alpha.12",
     "cheerio": "^0.22.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",


### PR DESCRIPTION
It looks like 1.0.0 of this module was accidentally published to npm, meaning the caret in package.json will always install that version rather than the later alpha versions, which don't have the `svg-to-png` dependency which causes a lot of warnings on npm install.