### PR TITLE
fix(themes): adjust styles for original and stripe themes

### DIFF
--- a/src/resources/styles/monokai-sublime.css
+++ b/src/resources/styles/monokai-sublime.css
@@ -12,7 +12,6 @@ Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-lic
 }
 
 .hljs,
-.hljs-tag,
 .hljs-subst {
   color: #f8f8f2;
 }

--- a/src/resources/styles/original.css
+++ b/src/resources/styles/original.css
@@ -45,3 +45,8 @@
 .menu ul.list li.divider {
     margin: 0;
 }
+
+.hljs-tag {
+    color: #f8f8f2;
+}
+

--- a/src/resources/styles/stripe.css
+++ b/src/resources/styles/stripe.css
@@ -69,3 +69,7 @@ pre code.hljs {
     border: none;
     background: #272b2d;
 }
+
+.hljs-tag {
+    color: #f8f8f2;
+}


### PR DESCRIPTION
Following characters is not visible in example section for laravel, postmark, readthedocs and vagrant themes: <, >, [, ], / and etc.