### PR TITLE
fix(search-engine): COMPODOC_SEARCH_INDEX

### DIFF
--- a/src/app/engines/search.engine.ts
+++ b/src/app/engines/search.engine.ts
@@ -41,9 +41,10 @@ export class SearchEngine {
             body: text
         };
 
-        this.documentsStore[doc.url] = doc;
-
-        this.getSearchIndex().add(doc);
+        if (!this.documentsStore.hasOwnProperty(doc.url)) {
+            this.documentsStore[doc.url] = doc;
+            this.getSearchIndex().add(doc);
+        }
     }
     generateSearchIndexJson(outputFolder) {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
**Invalid JSON is creating an issue when rendering the object to the template**

I found cases where modules where being included twice, I believe it's due to the "replace" on the `doc.url`. This formed an invalid json object when inserted into the .hbs template. Now it only writes to the object when the property doesn't exist, this fixes this bug but potentially there is a better way of handling the issue.

Related to #187 