### PR TITLE
refactor(html-engine-helpers): Seperated HandleBar helpers into indiviual files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 
 #ide folders
 .idea/
+.vscode/
 
 # Optional npm cache directory
 .npm

--- a/src/app/compiler/deps/component-dep.factory.ts
+++ b/src/app/compiler/deps/component-dep.factory.ts
@@ -4,15 +4,17 @@ import { ComponentHelper } from './helpers/component-helper';
 import { cleanLifecycleHooksFromMethods } from '../../../utils/utils';
 import { NsModuleCache } from './helpers/symbol-helper';
 import { ClassHelper } from './helpers/class-helper';
+import { ConfigurationInterface } from '../../interfaces/configuration.interface';
 
 export class ComponentDepFactory {
-    constructor(private helper: ComponentHelper) {
+    constructor(
+        private helper: ComponentHelper,
+        private configuration: ConfigurationInterface) {
 
     }
 
     public create(file: any, srcFile: any, name: any, props: any, IO: any): IComponentDep {
         // console.log(util.inspect(props, { showHidden: true, depth: 10 }));
-        const configuration = Configuration.getInstance();
         let componentDep: IComponentDep = {
             name,
             id: 'component-' + name + '-' + Date.now(),
@@ -48,7 +50,7 @@ export class ComponentDepFactory {
             sourceCode: srcFile.getText(),
             exampleUrls: this.helper.getComponentExampleUrls(srcFile.getText())
         };
-        if (configuration.mainData.disablePrivateOrInternalSupport) {
+        if (this.configuration.mainData.disablePrivateOrInternalSupport) {
             componentDep.methodsClass = cleanLifecycleHooksFromMethods(componentDep.methodsClass);
         }
         if (IO.jsdoctags && IO.jsdoctags.length > 0) {

--- a/src/app/compiler/deps/helpers/class-helper.ts
+++ b/src/app/compiler/deps/helpers/class-helper.ts
@@ -12,7 +12,7 @@ export class ClassHelper {
 
     constructor(
         private typeChecker,
-        private configuration: Configuration) {
+        private configuration: ConfigurationInterface) {
 
     }
 

--- a/src/app/compiler/deps/helpers/component-helper.ts
+++ b/src/app/compiler/deps/helpers/component-helper.ts
@@ -1,9 +1,10 @@
+const ts = require('typescript');
 import { SymbolHelper, NsModuleCache } from './symbol-helper';
 import { NodeObject } from '../../node-object.interface';
 import { detectIndent } from '../../../../utilities';
 import { IDep, Deps } from '../../dependencies.interfaces';
 import { ClassHelper } from './class-helper';
-const ts = require('typescript');
+
 
 export class ComponentHelper {
     constructor(
@@ -72,10 +73,10 @@ export class ComponentHelper {
             .map((name) => this.symbolHelper.parseDeepIndentifier(name, this.moduleCache));
     }
 
-    public getComponentTemplateUrl(props: NodeObject[]): string[] {
+    public getComponentTemplateUrl(props: Array<NodeObject>): Array<string> {
         return this.symbolHelper.getSymbolDeps(props, 'templateUrl');
     }
-    public getComponentExampleUrls(text: string) {
+    public getComponentExampleUrls(text: string): Array<string> | undefined {
         let exampleUrlsMatches = text.match(/<example-url>(.*?)<\/example-url>/g);
         let exampleUrls = undefined;
         if (exampleUrlsMatches && exampleUrlsMatches.length) {
@@ -106,7 +107,7 @@ export class ComponentHelper {
         return deps.map(parseProperties).pop();
     }
 
-    public getComponentIO(filename: string, sourceFile, node) {
+    public getComponentIO(filename: string, sourceFile: ts.SourceFile, node: ts.Node): any {
         /**
          * Copyright https://github.com/ng-bootstrap/ng-bootstrap
          */
@@ -114,7 +115,7 @@ export class ComponentHelper {
 
             if (statement.kind === ts.SyntaxKind.ClassDeclaration) {
                 if (statement.pos === node.pos && statement.end === node.end) {
-                    return directive.concat(this.classHelper.visitClassDeclaration(filename, statement, sourceFile));
+                    return directive.concat(this.classHelper.visitClassDeclaration(filename, statement as ts.ClassDeclaration, sourceFile));
                 }
             }
 
@@ -124,7 +125,7 @@ export class ComponentHelper {
         return res[0] || {};
     }
 
-    private sanitizeUrls(urls: string[]) {
+    private sanitizeUrls(urls: Array<string>): Array<string> {
         return urls.map(url => url.replace('./', ''));
     }
 }

--- a/src/app/compiler/deps/helpers/module-helper.ts
+++ b/src/app/compiler/deps/helpers/module-helper.ts
@@ -12,9 +12,9 @@ export class ModuleHelper {
     }
 
     public getModuleProviders(props: NodeObject[]): Deps[] {
-        return this.symbolHelper.getSymbolDeps(props, 'providers').map((providerName) => {
-            return this.symbolHelper.parseDeepIndentifier(providerName, this.moduleCache);
-        });
+        return this.symbolHelper
+            .getSymbolDeps(props, 'providers')
+            .map((providerName) => this.symbolHelper.parseDeepIndentifier(providerName, this.moduleCache));
     }
 
     public getModuleDeclations(props: NodeObject[]): Deps[] {
@@ -30,15 +30,15 @@ export class ModuleHelper {
     }
 
     public getModuleImports(props: NodeObject[]): Deps[] {
-        return this.symbolHelper.getSymbolDeps(props, 'imports').map((name) => {
-            return this.symbolHelper.parseDeepIndentifier(name, this.moduleCache);
-        });
+        return this.symbolHelper
+            .getSymbolDeps(props, 'imports')
+            .map((name) => this.symbolHelper.parseDeepIndentifier(name, this.moduleCache));
     }
 
     public getModuleExports(props: NodeObject[]): Deps[] {
-        return this.symbolHelper.getSymbolDeps(props, 'exports').map((name) => {
-            return this.symbolHelper.parseDeepIndentifier(name, this.moduleCache);
-        });
+        return this.symbolHelper
+            .getSymbolDeps(props, 'exports')
+            .map((name) => this.symbolHelper.parseDeepIndentifier(name, this.moduleCache));
     }
 
     public getModuleImportsRaw(props: NodeObject[]): Deps[] {
@@ -46,8 +46,8 @@ export class ModuleHelper {
     }
 
     public getModuleBootstrap(props: NodeObject[]): Deps[] {
-        return this.symbolHelper.getSymbolDeps(props, 'bootstrap').map((name) => {
-            return this.symbolHelper.parseDeepIndentifier(name, this.moduleCache);
-        });
+        return this.symbolHelper
+            .getSymbolDeps(props, 'bootstrap')
+            .map((name) => this.symbolHelper.parseDeepIndentifier(name, this.moduleCache));
     }
 }

--- a/src/app/compiler/deps/module-dep.factory.ts
+++ b/src/app/compiler/deps/module-dep.factory.ts
@@ -3,6 +3,7 @@ import { NodeObject } from '../node-object.interface';
 import { ModuleHelper } from './helpers/module-helper';
 import { NsModuleCache } from './helpers/symbol-helper';
 import { ComponentCache } from './helpers/component-helper';
+const ts = require('typescript');
 
 
 
@@ -11,7 +12,7 @@ export class ModuleDepFactory {
 
     }
 
-    public create(file: any, srcFile: any, name: any, props: any, IO: any): IModuleDep {
+    public create(file: any, srcFile: ts.SourceFile, name: any, props: any, IO: any): IModuleDep {
         return {
             name,
             id: 'module-' + name + '-' + Date.now(),

--- a/src/app/configuration.ts
+++ b/src/app/configuration.ts
@@ -1,17 +1,11 @@
 import { COMPODOC_DEFAULTS } from '../utils/defaults';
-
 import { PageInterface } from './interfaces/page.interface';
-
 import { MainDataInterface } from './interfaces/main-data.interface';
-
 import { ConfigurationInterface } from './interfaces/configuration.interface';
-
-const _ = require('lodash');
+import * as _ from 'lodash';
 
 export class Configuration implements ConfigurationInterface {
-    private static _instance:Configuration = new Configuration();
-
-    private _pages:PageInterface[] = [];
+    private _pages: PageInterface[] = [];
     private _mainData: MainDataInterface = {
         output: COMPODOC_DEFAULTS.folder,
         theme: COMPODOC_DEFAULTS.theme,
@@ -60,62 +54,50 @@ export class Configuration implements ConfigurationInterface {
         angularVersion: ''
     };
 
-    constructor() {
-        if(Configuration._instance){
-            throw new Error('Error: Instantiation failed: Use Configuration.getInstance() instead of new.');
-        }
-        Configuration._instance = this;
-    }
-
-    public static getInstance():Configuration
-    {
-        return Configuration._instance;
-    }
-
-    addPage(page: PageInterface) {
-        let indexPage = _.findIndex(this._pages, {'name': page.name});
+    public addPage(page: PageInterface) {
+        let indexPage = _.findIndex(this._pages, { 'name': page.name });
         if (indexPage === -1) {
             this._pages.push(page);
         }
     }
 
-    addAdditionalPage(page: PageInterface) {
+    public addAdditionalPage(page: PageInterface) {
         this._mainData.additionalPages.push(page);
     }
 
-    resetPages() {
+    public resetPages() {
         this._pages = [];
     }
 
-    resetAdditionalPages() {
+    public resetAdditionalPages() {
         this._mainData.additionalPages = [];
     }
 
-    resetRootMarkdownPages() {
-        let indexPage = _.findIndex(this._pages, {'name': 'index'});
+    public resetRootMarkdownPages() {
+        let indexPage = _.findIndex(this._pages, { 'name': 'index' });
         this._pages.splice(indexPage, 1);
-        indexPage = _.findIndex(this._pages, {'name': 'changelog'});
+        indexPage = _.findIndex(this._pages, { 'name': 'changelog' });
         this._pages.splice(indexPage, 1);
-        indexPage = _.findIndex(this._pages, {'name': 'contributing'});
+        indexPage = _.findIndex(this._pages, { 'name': 'contributing' });
         this._pages.splice(indexPage, 1);
-        indexPage = _.findIndex(this._pages, {'name': 'license'});
+        indexPage = _.findIndex(this._pages, { 'name': 'license' });
         this._pages.splice(indexPage, 1);
-        indexPage = _.findIndex(this._pages, {'name': 'todo'});
+        indexPage = _.findIndex(this._pages, { 'name': 'todo' });
         this._pages.splice(indexPage, 1);
         this._mainData.markdowns = [];
     }
 
-    get pages():PageInterface[] {
+    get pages(): PageInterface[] {
         return this._pages;
     }
-    set pages(pages:PageInterface[]) {
+    set pages(pages: PageInterface[]) {
         this._pages = [];
     }
 
-    get mainData():MainDataInterface {
+    get mainData(): MainDataInterface {
         return this._mainData;
     }
-    set mainData(data:MainDataInterface) {
-        (<any>Object).assign(this._mainData, data);
+    set mainData(data: MainDataInterface) {
+        (Object as any).assign(this._mainData, data);
     }
-};
+}

--- a/src/app/engines/file.engine.ts
+++ b/src/app/engines/file.engine.ts
@@ -1,13 +1,9 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as Handlebars from 'handlebars';
 
 export class FileEngine {
-    constructor() {
-
-    }
-    get(filepath:string) {
-        return new Promise(function(resolve, reject) {
+    public get(filepath:  string): Promise<string> {
+        return new Promise((resolve, reject) => {
            fs.readFile(path.resolve(process.cwd() + path.sep + filepath), 'utf8', (err, data) => {
                if (err) {
                    reject('Error during ' + filepath + ' read');
@@ -17,4 +13,4 @@ export class FileEngine {
            });
         });
     }
-};
+}

--- a/src/app/engines/html-engine-helpers/break-comma.helper.ts
+++ b/src/app/engines/html-engine-helpers/break-comma.helper.ts
@@ -1,0 +1,12 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import * as Handlebars from 'handlebars';
+
+export class BreakCommaHelper implements IHtmlEngineHelper {
+    constructor(private bars) { }
+
+    public helperFunc(context: any, text) {
+        text = this.bars.Utils.escapeExpression(text);
+        text = text.replace(/,/g, ',<br>');
+        return new Handlebars.SafeString(text);
+    }
+}

--- a/src/app/engines/html-engine-helpers/break-lines.helper.ts
+++ b/src/app/engines/html-engine-helpers/break-lines.helper.ts
@@ -1,0 +1,16 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import * as Handlebars from 'handlebars';
+
+export class BreakLinesHelper implements IHtmlEngineHelper {
+    constructor(private bars) {
+
+    }
+
+    public helperFunc(context: any, text) {
+        text = this.bars.Utils.escapeExpression(text);
+        text = text.replace(/(\r\n|\n|\r)/gm, '<br>');
+        text = text.replace(/ /gm, '&nbsp;');
+        text = text.replace(/	/gm, '&nbsp;&nbsp;&nbsp;&nbsp;');
+        return new Handlebars.SafeString(text);
+    }
+}

--- a/src/app/engines/html-engine-helpers/clean-paragraph.helper.ts
+++ b/src/app/engines/html-engine-helpers/clean-paragraph.helper.ts
@@ -1,0 +1,10 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import * as Handlebars from 'handlebars';
+
+export class CleanParagraphHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, text) {
+        text = text.replace(/<p>/gm, '');
+        text = text.replace(/<\/p>/gm, '');
+        return new Handlebars.SafeString(text);
+    }
+}

--- a/src/app/engines/html-engine-helpers/compare.helper.ts
+++ b/src/app/engines/html-engine-helpers/compare.helper.ts
@@ -1,0 +1,33 @@
+import { IHtmlEngineHelper, IHandlebarsOptions } from './html-engine-helper.interface';
+
+export class CompareHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, a, operator, b, options: IHandlebarsOptions) {
+        if (arguments.length < 4) {
+            throw new Error('handlebars Helper {{compare}} expects 4 arguments');
+        }
+
+        let result;
+        switch (operator) {
+            case 'indexof':
+                result = (b.indexOf(a) !== -1);
+                break;
+            case '===':
+                result = a === b;
+                break;
+            case '!==':
+                result = a !== b;
+                break;
+            case '>':
+                result = a > b;
+                break;
+            default: {
+                throw new Error('helper {{compare}}: invalid operator: `' + operator + '`');
+            }
+        }
+
+        if (result === false) {
+            return options.inverse(context);
+        }
+        return options.fn(context);
+    }
+}

--- a/src/app/engines/html-engine-helpers/debug.helper.ts
+++ b/src/app/engines/html-engine-helpers/debug.helper.ts
@@ -1,0 +1,15 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class DebugHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, optionalValue) {
+        console.log('Current Context');
+        console.log('====================');
+        console.log(context);
+
+        if (optionalValue) {
+            console.log('OptionalValue');
+            console.log('====================');
+            console.log(optionalValue);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/escape-simple-quote.helper.ts
+++ b/src/app/engines/html-engine-helpers/escape-simple-quote.helper.ts
@@ -1,0 +1,12 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class EscapeSimpleQuoteHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, text) {
+        if (!text) {
+            return;
+        }
+        let _text = text.replace(/'/g, "\\'");
+        _text = _text.replace(/(\r\n|\n|\r)/gm, '');
+        return _text;
+    }
+}

--- a/src/app/engines/html-engine-helpers/filter-angular2-modules.helper.ts
+++ b/src/app/engines/html-engine-helpers/filter-angular2-modules.helper.ts
@@ -1,0 +1,25 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class FilterAngular2ModulesHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, text, options) {
+        const NG2_MODULES: string[] = [
+            'BrowserModule',
+            'FormsModule',
+            'HttpModule',
+            'RouterModule'
+        ];
+        let len = NG2_MODULES.length;
+        let i = 0;
+        let result = false;
+        for (i; i < len; i++) {
+            if (text.indexOf(NG2_MODULES[i]) > -1) {
+                result = true;
+            }
+        }
+        if (result) {
+            return options.fn(context);
+        } else {
+            return options.inverse(context);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/function-signature.helper.ts
+++ b/src/app/engines/html-engine-helpers/function-signature.helper.ts
@@ -1,0 +1,90 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import { prefixOfficialDoc } from '../../../utils/angular-version';
+import { DependenciesEngine } from '../dependencies.engine';
+import { finderInBasicTypes, finderInTypeScriptBasicTypes } from '../../../utils/basic-types';
+import { ConfigurationInterface } from '../../interfaces/configuration.interface';
+
+export class FunctionSignatureHelper implements IHtmlEngineHelper {
+    constructor(
+        private configuration: ConfigurationInterface,
+        private dependenciesEngine: DependenciesEngine) {
+
+    }
+
+    private handleFunction(arg) {
+        let angularDocPrefix = prefixOfficialDoc(this.configuration.mainData.angularVersion);
+
+        if (arg.function.length === 0) {
+            return `${arg.name}${this.getOptionalString(arg)}: () => void`;
+        }
+
+        let argums = arg.function.map((argu) => {
+            let _result = this.dependenciesEngine.find(argu.type);
+            if (_result) {
+                if (_result.source === 'internal') {
+                    let path = _result.data.type;
+                    if (_result.data.type === 'class') { path = 'classe'; }
+                    return `${argu.name}${this.getOptionalString(arg)}: <a href="../${path}s/${_result.data.name}.html">${argu.type}</a>`;
+                } else {
+                    let path = `https://${angularDocPrefix}angular.io/docs/ts/latest/api/${_result.data.path}`;
+                    return `${argu.name}${this.getOptionalString(arg)}: <a href="${path}" target="_blank">${argu.type}</a>`;
+                }
+            } else if (finderInBasicTypes(argu.type)) {
+                let path = `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/${argu.type}`;
+                return `${argu.name}${this.getOptionalString(arg)}: <a href="${path}" target="_blank">${argu.type}</a>`;
+            } else if (finderInTypeScriptBasicTypes(argu.type)) {
+                let path = `https://www.typescriptlang.org/docs/handbook/basic-types.html`;
+                return `${argu.name}${this.getOptionalString(arg)}: <a href="${path}" target="_blank">${argu.type}</a>`;
+            } else {
+                if (argu.name && argu.type) {
+                    return `${argu.name}${this.getOptionalString(arg)}: ${argu.type}`;
+                } else {
+                    return `${argu.name.text}`;
+                }
+            }
+        });
+        return `${arg.name}${this.getOptionalString(arg)}: (${argums}) => void`;
+    }
+
+    private getOptionalString(arg): string {
+        return arg.optional ? '?' : '';
+    }
+
+    public helperFunc(context: any, method) {
+        let args = [];
+        let angularDocPrefix = prefixOfficialDoc(this.configuration.mainData.angularVersion);
+
+        if (method.args) {
+            args = method.args.map((arg) => {
+                let _result = this.dependenciesEngine.find(arg.type);
+                if (_result) {
+                    if (_result.source === 'internal') {
+                        let path = _result.data.type;
+                        if (_result.data.type === 'class') { path = 'classe'; }
+                        return `${arg.name}${this.getOptionalString(arg)}: <a href="../${path}s/${_result.data.name}.html">${arg.type}</a>`;
+                    } else {
+                        let path = `https://${angularDocPrefix}angular.io/docs/ts/latest/api/${_result.data.path}`;
+                        return `${arg.name}${this.getOptionalString(arg)}: <a href="${path}" target="_blank">${arg.type}</a>`;
+                    }
+                } else if (arg.dotDotDotToken) {
+                    return `...${arg.name}: ${arg.type}`;
+                } else if (arg.function) {
+                    return this.handleFunction(arg);
+                } else if (finderInBasicTypes(arg.type)) {
+                    let path = `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/${arg.type}`;
+                    return `${arg.name}${this.getOptionalString(arg)}: <a href="${path}" target="_blank">${arg.type}</a>`;
+                } else if (finderInTypeScriptBasicTypes(arg.type)) {
+                    let path = `https://www.typescriptlang.org/docs/handbook/basic-types.html`;
+                    return `${arg.name}${this.getOptionalString(arg)}: <a href="${path}" target="_blank">${arg.type}</a>`;
+                } else {
+                    return `${arg.name}${this.getOptionalString(arg)}: ${arg.type}`;
+                }
+            }).join(', ');
+        }
+        if (method.name) {
+            return `${method.name}(${args})`;
+        } else {
+            return `(${args})`;
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/html-engine-helper.interface.ts
+++ b/src/app/engines/html-engine-helpers/html-engine-helper.interface.ts
@@ -1,0 +1,10 @@
+import { Configuration } from '../../configuration';
+
+export interface IHtmlEngineHelper {
+    helperFunc(context: any, ...args: any[]): any;
+}
+
+export interface IHandlebarsOptions {
+    fn(context): string;
+    inverse(context: string): string;
+}

--- a/src/app/engines/html-engine-helpers/if-string.helper.ts
+++ b/src/app/engines/html-engine-helpers/if-string.helper.ts
@@ -1,0 +1,10 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class IfStringHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, a, options) {
+        if (typeof a === 'string') {
+            return options.fn(context);
+        }
+        return options.inverse(context);
+    }
+}

--- a/src/app/engines/html-engine-helpers/indexable-signature.helper.ts
+++ b/src/app/engines/html-engine-helpers/indexable-signature.helper.ts
@@ -1,0 +1,12 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class IndexableSignatureHelper implements IHtmlEngineHelper {
+	public helperFunc(context: any, method) {
+            const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
+            if (method.name) {
+                return `${method.name}[${args}]`;
+            } else {
+                return `[${args}]`;
+            }
+        }
+}

--- a/src/app/engines/html-engine-helpers/is-not-toggle.helper.ts
+++ b/src/app/engines/html-engine-helpers/is-not-toggle.helper.ts
@@ -1,0 +1,20 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import { ConfigurationInterface } from '../../interfaces/configuration.interface';
+
+export class IsNotToggleHelper implements IHtmlEngineHelper {
+    constructor(private configuration: ConfigurationInterface) {
+
+    }
+
+    public helperFunc(context: any, type, options) {
+        let result = this.configuration.mainData.toggleMenuItems.indexOf(type);
+
+        if (this.configuration.mainData.toggleMenuItems.indexOf('all') !== -1) {
+            return options.inverse(context);
+        } else if (result === -1) {
+            return options.fn(context);
+        } else {
+            return options.inverse(context);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/jsdoc-code-example.helper.ts
+++ b/src/app/engines/html-engine-helpers/jsdoc-code-example.helper.ts
@@ -1,0 +1,60 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import { JsdocTagInterface } from '../../interfaces/jsdoc-tag.interface';
+
+export class JsdocCodeExampleHelper implements IHtmlEngineHelper {
+
+    private cleanTag(comment) {
+        if (comment.charAt(0) === '*') {
+            comment = comment.substring(1, comment.length);
+        }
+        if (comment.charAt(0) === ' ') {
+            comment = comment.substring(1, comment.length);
+        }
+        if (comment.indexOf('<p>') === 0) {
+            comment = comment.substring(3, comment.length);
+        }
+        if (comment.substr(-1) === '\n') {
+            comment = comment.substring(0, comment.length - 1);
+        }
+        if (comment.substr(-4) === '</p>') {
+            comment = comment.substring(0, comment.length - 4);
+        }
+        return comment;
+    }
+
+    private getHtmlEntities(str): string {
+        return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    public helperFunc(context: any, jsdocTags: JsdocTagInterface[], options) {
+        let i = 0;
+        let len = jsdocTags.length;
+        let tags = [];
+        let type = 'html';
+
+        if (options.hash.type) {
+            type = options.hash.type;
+        }
+
+        for (i; i < len; i++) {
+            if (jsdocTags[i].tagName) {
+                if (jsdocTags[i].tagName.text === 'example') {
+                    let tag = {} as JsdocTagInterface;
+                    if (jsdocTags[i].comment) {
+                        if (jsdocTags[i].comment.indexOf('<caption>') !== -1) {
+                            tag.comment = jsdocTags[i].comment.replace(/<caption>/g, '<b><i>').replace(/\/caption>/g, '/b></i>');
+                        } else {
+                            tag.comment = `<pre class="line-numbers"><code class="language-${type}">` +
+                                this.getHtmlEntities(this.cleanTag(jsdocTags[i].comment)) + `</code></pre>`;
+                        }
+                    }
+                    tags.push(tag);
+                }
+            }
+        }
+        if (tags.length > 0) {
+            context.tags = tags;
+            return options.fn(context);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/jsdoc-default.helper.ts
+++ b/src/app/engines/html-engine-helpers/jsdoc-default.helper.ts
@@ -1,0 +1,34 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import { JsdocTagInterface } from '../../interfaces/jsdoc-tag.interface';
+
+export class JsdocDefaultHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, jsdocTags: JsdocTagInterface[], options) {
+        if (jsdocTags) {
+            let i = 0;
+            let len = jsdocTags.length;
+            let tag = {} as JsdocTagInterface;
+            let defaultValue = false;
+
+            for (i; i < len; i++) {
+                if (jsdocTags[i].tagName) {
+                    if (jsdocTags[i].tagName.text === 'default') {
+                        defaultValue = true;
+                        if (jsdocTags[i].typeExpression && jsdocTags[i].typeExpression.type.name) {
+                            tag.type = jsdocTags[i].typeExpression.type.name.text;
+                        }
+                        if (jsdocTags[i].comment) {
+                            tag.comment = jsdocTags[i].comment;
+                        }
+                        if (jsdocTags[i].name) {
+                            tag.name = jsdocTags[i].name.text;
+                        }
+                    }
+                }
+            }
+            if (defaultValue) {
+                context.tag = tag;
+                return options.fn(context);
+            }
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/jsdoc-example.helper.ts
+++ b/src/app/engines/html-engine-helpers/jsdoc-example.helper.ts
@@ -1,0 +1,26 @@
+import { JsdocTagInterface } from '../../interfaces/jsdoc-tag.interface';
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class JsdocExampleHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, jsdocTags: JsdocTagInterface[], options) {
+        let i = 0;
+        let len = jsdocTags.length;
+        let tags = [];
+
+        for (i; i < len; i++) {
+            if (jsdocTags[i].tagName) {
+                if (jsdocTags[i].tagName.text === 'example') {
+                    let tag = {} as JsdocTagInterface;
+                    if (jsdocTags[i].comment) {
+                        tag.comment = jsdocTags[i].comment.replace(/<caption>/g, '<b><i>').replace(/\/caption>/g, '/b></i>');
+                    }
+                    tags.push(tag);
+                }
+            }
+        }
+        if (tags.length > 0) {
+            context.tags = tags;
+            return options.fn(context);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/jsdoc-params-valid.helper.ts
+++ b/src/app/engines/html-engine-helpers/jsdoc-params-valid.helper.ts
@@ -1,0 +1,24 @@
+import { IHtmlEngineHelper, IHandlebarsOptions } from './html-engine-helper.interface';
+import { JsdocTagInterface } from '../../interfaces/jsdoc-tag.interface';
+
+export class JsdocParamsValidHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, jsdocTags: JsdocTagInterface[], options: IHandlebarsOptions) {
+        let i = 0;
+        let len = jsdocTags.length;
+        let tags = [];
+        let valid = false;
+
+        for (i; i < len; i++) {
+            if (jsdocTags[i].tagName) {
+                if (jsdocTags[i].tagName.text === 'param') {
+                    valid = true;
+                }
+            }
+        }
+        if (valid) {
+            return options.fn(context);
+        } else {
+            return options.inverse(context);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/jsdoc-params.helper.ts
+++ b/src/app/engines/html-engine-helpers/jsdoc-params.helper.ts
@@ -1,0 +1,45 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import { JsdocTagInterface } from '../../interfaces/jsdoc-tag.interface';
+import { kindToType } from '../../../utils/kind-to-type';
+
+export class JsdocParamsHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, jsdocTags: Array<JsdocTagInterface | any>, options) {
+        let i = 0;
+        let len = jsdocTags.length;
+        let tags = [];
+
+        for (i; i < len; i++) {
+            if (jsdocTags[i].tagName) {
+                if (jsdocTags[i].tagName.text === 'param') {
+                    let tag = {} as JsdocTagInterface;
+                    if (jsdocTags[i].typeExpression && jsdocTags[i].typeExpression.type.kind) {
+                        tag.type = kindToType(jsdocTags[i].typeExpression.type.kind);
+                    }
+                    if (jsdocTags[i].typeExpression && jsdocTags[i].typeExpression.type.name) {
+                        tag.type = jsdocTags[i].typeExpression.type.name.text;
+                    } else {
+                        tag.type = jsdocTags[i].type;
+                    }
+                    if (jsdocTags[i].comment) {
+                        tag.comment = jsdocTags[i].comment;
+                    }
+                    if (jsdocTags[i].name) {
+                        if (jsdocTags[i].name.text) {
+                            tag.name = jsdocTags[i].name.text;
+                        } else {
+                            tag.name = jsdocTags[i].name;
+                        }
+                    }
+                    if (jsdocTags[i].optional) {
+                        (tag as any).optional = true;
+                    }
+                    tags.push(tag);
+                }
+            }
+        }
+        if (tags.length >= 1) {
+            context.tags = tags;
+            return options.fn(context);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/jsdoc-returns-comment.helper.ts
+++ b/src/app/engines/html-engine-helpers/jsdoc-returns-comment.helper.ts
@@ -1,0 +1,18 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class JsdocReturnsCommentHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, jsdocTags, options) {
+        let i = 0;
+        let len = jsdocTags.length;
+        let result;
+        for (i; i < len; i++) {
+            if (jsdocTags[i].tagName) {
+                if (jsdocTags[i].tagName.text === 'returns') {
+                    result = jsdocTags[i].comment;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/app/engines/html-engine-helpers/link-type.helper.ts
+++ b/src/app/engines/html-engine-helpers/link-type.helper.ts
@@ -1,0 +1,68 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import { DependenciesEngine } from '../dependencies.engine';
+import { prefixOfficialDoc } from '../../../utils/angular-version';
+import { finderInBasicTypes, finderInTypeScriptBasicTypes } from '../../../utils/basic-types';
+import { ConfigurationInterface } from '../../interfaces/configuration.interface';
+
+export class LinkTypeHelper implements IHtmlEngineHelper {
+    constructor(
+        private configuration: ConfigurationInterface,
+        private dependenciesEngine: DependenciesEngine) {
+
+    }
+
+    public helperFunc(context: any, name, options) {
+        let _result = this.dependenciesEngine.find(name);
+        let angularDocPrefix = prefixOfficialDoc(this.configuration.mainData.angularVersion);
+        if (_result) {
+            context.type = {
+                raw: name
+            };
+            if (_result.source === 'internal') {
+                if (_result.data.type === 'class') {
+                    _result.data.type = 'classe';
+                }
+                context.type.href = '../' + _result.data.type + 's/' + _result.data.name + '.html';
+                if (_result.data.type === 'miscellaneous') {
+                    let mainpage = '';
+                    switch (_result.data.subtype) {
+                        case 'enum':
+                            mainpage = 'enumerations';
+                            break;
+                        case 'function':
+                            mainpage = 'functions';
+                            break;
+                        case 'typealias':
+                            mainpage = 'typealiases';
+                            break;
+                        case 'variable':
+                            mainpage = 'variables';
+                    }
+                    context.type.href = '../' + _result.data.type + '/' + mainpage + '.html#' + _result.data.name;
+                }
+                context.type.target = '_self';
+            } else {
+                context.type.href = `https://${angularDocPrefix}angular.io/docs/ts/latest/api/${_result.data.path}`;
+                context.type.target = '_blank';
+            }
+
+            return options.fn(context);
+        } else if (finderInBasicTypes(name)) {
+            context.type = {
+                raw: name
+            };
+            context.type.target = '_blank';
+            context.type.href = `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/${name}`;
+            return options.fn(context);
+        } else if (finderInTypeScriptBasicTypes(name)) {
+            context.type = {
+                raw: name
+            };
+            context.type.target = '_blank';
+            context.type.href = 'https://www.typescriptlang.org/docs/handbook/basic-types.html';
+            return options.fn(context);
+        } else {
+            return options.inverse(context);
+        }
+    }
+}

--- a/src/app/engines/html-engine-helpers/modif-icon.helper.ts
+++ b/src/app/engines/html-engine-helpers/modif-icon.helper.ts
@@ -1,0 +1,26 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class ModifIconHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, kind) {
+        // https://github.com/Microsoft/TypeScript/blob/master/lib/typescript.d.ts#L62
+        let _kindText = '';
+        switch (kind) {
+            case 112:
+                _kindText = 'lock'; // private
+                break;
+            case 113:
+                _kindText = 'lock'; // protected
+                break;
+            case 115:
+                _kindText = 'reset'; // static
+                break;
+            case 84:
+                _kindText = 'export'; // export
+                break;
+            default:
+                _kindText = 'reset';
+                break;
+        }
+        return _kindText;
+    }
+}

--- a/src/app/engines/html-engine-helpers/modif-kind-helper.ts
+++ b/src/app/engines/html-engine-helpers/modif-kind-helper.ts
@@ -1,0 +1,24 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import * as Handlebars from 'handlebars';
+
+export class ModifKindHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, kind) {
+        // https://github.com/Microsoft/TypeScript/blob/master/lib/typescript.d.ts#L62
+        let _kindText = '';
+        switch (kind) {
+            case 112:
+                _kindText = 'Private';
+                break;
+            case 113:
+                _kindText = 'Protected';
+                break;
+            case 114:
+                _kindText = 'Public';
+                break;
+            case 115:
+                _kindText = 'Static';
+                break;
+        }
+        return new Handlebars.SafeString(_kindText);
+    }
+}

--- a/src/app/engines/html-engine-helpers/object.helper.ts
+++ b/src/app/engines/html-engine-helpers/object.helper.ts
@@ -1,0 +1,12 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import * as Handlebars from 'handlebars';
+
+export class ObjectHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, text) {
+        text = JSON.stringify(text);
+        text = text.replace(/{"/, '{<br>&nbsp;&nbsp;&nbsp;&nbsp;"');
+        text = text.replace(/,"/, ',<br>&nbsp;&nbsp;&nbsp;&nbsp;"');
+        text = text.replace(/}$/, '<br>}');
+        return new Handlebars.SafeString(text);
+    }
+}

--- a/src/app/engines/html-engine-helpers/or-length.helper.ts
+++ b/src/app/engines/html-engine-helpers/or-length.helper.ts
@@ -1,0 +1,19 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class OrLengthHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, /* any, any, ..., options */) {
+        let len = arguments.length - 1;
+        let options = arguments[len];
+
+        // We start at 1 because of options
+        for (let i = 1; i < len; i++) {
+            if (typeof arguments[i] !== 'undefined') {
+                if (arguments[i].length > 0) {
+                    return options.fn(context);
+                }
+            }
+        }
+
+        return options.inverse(context);
+    }
+}

--- a/src/app/engines/html-engine-helpers/or.helper.ts
+++ b/src/app/engines/html-engine-helpers/or.helper.ts
@@ -1,0 +1,17 @@
+import { IHtmlEngineHelper, IHandlebarsOptions } from './html-engine-helper.interface';
+
+export class OrHelper implements IHtmlEngineHelper {
+    public helperFunc(context: any, /* any, any, ..., options */) {
+        let len = arguments.length - 1;
+        let options: IHandlebarsOptions = arguments[len];
+
+        // We start at 1 because of options
+        for (let i = 1; i < len; i++) {
+            if (arguments[i]) {
+                return options.fn(context);
+            }
+        }
+
+        return options.inverse(context);
+    }
+}

--- a/src/app/engines/html-engine-helpers/parse-description.helper.ts
+++ b/src/app/engines/html-engine-helpers/parse-description.helper.ts
@@ -1,0 +1,117 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+import { extractLeadingText, splitLinkText } from '../../../utils/link-parser';
+import { DependenciesEngine } from '../dependencies.engine';
+
+export class ParseDescriptionHelper implements IHtmlEngineHelper {
+    constructor(private dependenciesEngine: DependenciesEngine) {
+
+    }
+
+    public helperFunc(context: any, description: string, depth: number) {
+        let tagRegExpLight = new RegExp('\\{@link\\s+((?:.|\n)+?)\\}', 'i');
+        let tagRegExpFull = new RegExp('\\{@link\\s+((?:.|\n)+?)\\}', 'i');
+        let tagRegExp;
+        let matches;
+        let previousString;
+        let tagInfo = [];
+
+        tagRegExp = (description.indexOf(']{') !== -1) ? tagRegExpFull : tagRegExpLight;
+
+        const processTheLink = (string, tagInfo, leadingText) => {
+            let leading = extractLeadingText(string, tagInfo.completeTag);
+            let split;
+            let result;
+            let newLink;
+            let rootPath;
+            let stringtoReplace;
+            let anchor = '';
+
+            split = splitLinkText(tagInfo.text);
+
+            if (typeof split.linkText !== 'undefined') {
+                result = this.dependenciesEngine.findInCompodoc(split.target);
+            } else {
+                let info = tagInfo.text;
+                if (tagInfo.text.indexOf('#') !== -1) {
+                    anchor = tagInfo.text.substr(tagInfo.text.indexOf('#'), tagInfo.text.length);
+                    info = tagInfo.text.substr(0, tagInfo.text.indexOf('#'));
+                }
+                result = this.dependenciesEngine.findInCompodoc(info);
+            }
+
+            if (result) {
+
+                if (leadingText) {
+                    stringtoReplace = '[' + leadingText + ']' + tagInfo.completeTag;
+                } else if (leading.leadingText !== null) {
+                    stringtoReplace = '[' + leading.leadingText + ']' + tagInfo.completeTag;
+                } else if (typeof split.linkText !== 'undefined') {
+                    stringtoReplace = tagInfo.completeTag;
+                } else {
+                    stringtoReplace = tagInfo.completeTag;
+                }
+
+                if (result.type === 'class') {
+                    result.type = 'classe';
+                }
+
+                rootPath = '';
+
+                switch (depth) {
+                    case 0:
+                        rootPath = './';
+                        break;
+                    case 1:
+                        rootPath = '../';
+                        break;
+                    case 2:
+                        rootPath = '../../';
+                        break;
+                }
+
+                let label = result.name;
+                if (leading.leadingText !== null) {
+                    label = leading.leadingText;
+                }
+                if (typeof split.linkText !== 'undefined') {
+                    label = split.linkText;
+                }
+
+                newLink = `<a href="${rootPath}${result.type}s/${result.name}.html${anchor}">${label}</a>`;
+                return string.replace(stringtoReplace, newLink);
+            } else {
+                return string;
+            }
+        };
+
+        function replaceMatch(replacer, tag, match, text, linkText?) {
+            let matchedTag = {
+                completeTag: match,
+                tag: tag,
+                text: text
+            };
+            tagInfo.push(matchedTag);
+
+            if (linkText) {
+                return replacer(description, matchedTag, linkText);
+            } else {
+                return replacer(description, matchedTag);
+            }
+        }
+
+        do {
+            matches = tagRegExp.exec(description);
+            if (matches) {
+                previousString = description;
+                if (matches.length === 2) {
+                    description = replaceMatch(processTheLink, 'link', matches[0], matches[1]);
+                }
+                if (matches.length === 3) {
+                    description = replaceMatch(processTheLink, 'link', matches[0], matches[2], matches[1]);
+                }
+            }
+        } while (matches && previousString !== description);
+
+        return description;
+    }
+}

--- a/src/app/engines/html-engine-helpers/relative-url.helper.ts
+++ b/src/app/engines/html-engine-helpers/relative-url.helper.ts
@@ -1,0 +1,21 @@
+import { IHtmlEngineHelper } from './html-engine-helper.interface';
+
+export class RelativeURLHelper implements IHtmlEngineHelper {
+    public helperFunc(ctx: any, currentDepth, context) {
+        let result = '';
+
+        switch (currentDepth) {
+            case 0:
+                result = './';
+                break;
+            case 1:
+                result = '../';
+                break;
+            case 2:
+                result = '../../';
+                break;
+        }
+
+        return result;
+    }
+}

--- a/src/app/engines/html.engine.helpers.ts
+++ b/src/app/engines/html.engine.helpers.ts
@@ -1,631 +1,75 @@
 import * as Handlebars from 'handlebars';
-import { COMPODOC_DEFAULTS } from '../../utils/defaults';
-import { $dependenciesEngine } from './dependencies.engine';
-import { extractLeadingText, splitLinkText } from '../../utils/link-parser';
-import { Configuration } from '../configuration';
-import { prefixOfficialDoc } from '../../utils/angular-version';
-
-import { jsdocTagInterface } from '../interfaces/jsdoc-tag.interface';
+import * as _ from 'lodash';
 
 import { finderInBasicTypes, finderInTypeScriptBasicTypes } from '../../utils/basic-types';
 import { kindToType } from '../../utils/kind-to-type';
+import { DependenciesEngine } from './dependencies.engine';
+import { IHtmlEngineHelper } from './html-engine-helpers/html-engine-helper.interface';
+import { CompareHelper } from './html-engine-helpers/compare.helper';
+import { OrHelper } from './html-engine-helpers/or.helper';
+import { FunctionSignatureHelper } from './html-engine-helpers/function-signature.helper';
+import { IsNotToggleHelper } from './html-engine-helpers/is-not-toggle.helper';
+import { IfStringHelper } from './html-engine-helpers/if-string.helper';
+import { OrLengthHelper } from './html-engine-helpers/or-length.helper';
+import { FilterAngular2ModulesHelper } from './html-engine-helpers/filter-angular2-modules.helper';
+import { DebugHelper } from './html-engine-helpers/debug.helper';
+import { BreakLinesHelper } from './html-engine-helpers/break-lines.helper';
+import { CleanParagraphHelper } from './html-engine-helpers/clean-paragraph.helper';
+import { EscapeSimpleQuoteHelper } from './html-engine-helpers/escape-simple-quote.helper';
+import { BreakCommaHelper } from './html-engine-helpers/break-comma.helper';
+import { ModifKindHelper } from './html-engine-helpers/modif-kind-helper';
+import { ModifIconHelper } from './html-engine-helpers/modif-icon.helper';
+import { RelativeURLHelper } from './html-engine-helpers/relative-url.helper';
+import { JsdocReturnsCommentHelper } from './html-engine-helpers/jsdoc-returns-comment.helper';
+import { JsdocCodeExampleHelper } from './html-engine-helpers/jsdoc-code-example.helper';
+import { JsdocExampleHelper } from './html-engine-helpers/jsdoc-example.helper';
+import { JsdocParamsHelper } from './html-engine-helpers/jsdoc-params.helper';
+import { JsdocParamsValidHelper } from './html-engine-helpers/jsdoc-params-valid.helper';
+import { JsdocDefaultHelper } from './html-engine-helpers/jsdoc-default.helper';
+import { LinkTypeHelper } from './html-engine-helpers/link-type.helper';
+import { IndexableSignatureHelper } from './html-engine-helpers/indexable-signature.helper';
+import { ObjectHelper } from './html-engine-helpers/object.helper';
+import { ParseDescriptionHelper } from './html-engine-helpers/parse-description.helper';
+import { ConfigurationInterface } from '../interfaces/configuration.interface';
 
-export let HtmlEngineHelpers = (function() {
-    let init = function() {
-        //TODO use this instead : https://github.com/assemble/handlebars-helpers
-        Handlebars.registerHelper( "compare", function(a, operator, b, options) {
-          if (arguments.length < 4) {
-            throw new Error('handlebars Helper {{compare}} expects 4 arguments');
-          }
 
-          var result;
-          switch (operator) {
-            case 'indexof':
-                result = (b.indexOf(a) !== -1);
-                break;
-            case '===':
-              result = a === b;
-              break;
-            case '!==':
-              result = a !== b;
-              break;
-            case '>':
-              result = a > b;
-              break;
-            default: {
-              throw new Error('helper {{compare}}: invalid operator: `' + operator + '`');
-            }
-          }
+export class HtmlEngineHelpers {
+    public registerHelpers(
+        bars,
+        configuration: ConfigurationInterface,
+        dependenciesEngine: DependenciesEngine): void {
 
-          if (result === false) {
-            return options.inverse(this);
-          }
-          return options.fn(this);
-        });
-        Handlebars.registerHelper("or", function(/* any, any, ..., options */) {
-            var len = arguments.length - 1;
-          var options = arguments[len];
+        this.registerHelper(bars, 'compare', new CompareHelper());
+        this.registerHelper(bars, 'or', new OrHelper());
+        this.registerHelper(bars, 'functionSignature', new FunctionSignatureHelper(configuration, dependenciesEngine));
+        this.registerHelper(bars, 'isNotToggle', new IsNotToggleHelper(configuration));
+        this.registerHelper(bars, 'ifString', new IfStringHelper());
+        this.registerHelper(bars, 'orLength', new OrLengthHelper());
+        this.registerHelper(bars, 'filterAngular2Modules', new FilterAngular2ModulesHelper());
+        this.registerHelper(bars, 'debug', new DebugHelper());
+        this.registerHelper(bars, 'breaklines', new BreakLinesHelper(bars));
+        this.registerHelper(bars, 'clean-paragraph', new CleanParagraphHelper());
+        this.registerHelper(bars, 'escapeSimpleQuote', new EscapeSimpleQuoteHelper());
+        this.registerHelper(bars, 'breakComma', new BreakCommaHelper(bars));
+        this.registerHelper(bars, 'modifKind', new ModifKindHelper());
+        this.registerHelper(bars, 'modifIcon', new ModifIconHelper());
+        this.registerHelper(bars, 'relativeURL', new RelativeURLHelper());
+        this.registerHelper(bars, 'jsdoc-returns-comment', new JsdocReturnsCommentHelper());
+        this.registerHelper(bars, 'jsdoc-code-example', new JsdocCodeExampleHelper());
+        this.registerHelper(bars, 'jsdoc-example', new JsdocExampleHelper());
+        this.registerHelper(bars, 'jsdoc-params', new JsdocParamsHelper());
+        this.registerHelper(bars, 'jsdoc-params-valid', new JsdocParamsValidHelper());
+        this.registerHelper(bars, 'jsdoc-default', new JsdocDefaultHelper());
+        this.registerHelper(bars, 'linkType', new LinkTypeHelper(configuration, dependenciesEngine));
+        this.registerHelper(bars, 'indexableSignature', new IndexableSignatureHelper());
+        this.registerHelper(bars, 'object', new ObjectHelper());
+        this.registerHelper(bars, 'parseDescription', new ParseDescriptionHelper(dependenciesEngine));
+    }
 
-          for (var i = 0; i < len; i++) {
-            if (arguments[i]) {
-              return options.fn(this);
-            }
-          }
-
-          return options.inverse(this);
-        });
-        Handlebars.registerHelper("ifString", function(a, options) {
-            if (typeof a === 'string') {
-              return options.fn(this);
-            }
-            return options.inverse(this);
-        });
-        Handlebars.registerHelper("orLength", function(/* any, any, ..., options */) {
-            var len = arguments.length - 1;
-          var options = arguments[len];
-          for (var i = 0; i < len; i++) {
-            if (typeof arguments[i] !== 'undefined') {
-                if(arguments[i].length > 0) {
-                  return options.fn(this);
-                }
-            }
-          }
-
-          return options.inverse(this);
-        });
-        Handlebars.registerHelper("filterAngular2Modules", function(text, options) {
-            const NG2_MODULES:string[] = [
-                'BrowserModule',
-                'FormsModule',
-                'HttpModule',
-                'RouterModule'
-            ],
-                len = NG2_MODULES.length;
-            let i = 0,
-                result = false;
-            for (i; i < len; i++) {
-                if (text.indexOf(NG2_MODULES[i]) > -1) {
-                    result = true;
-                }
-            }
-            if (result) {
-                return options.fn(this);
-            } else {
-                return options.inverse(this);
-            }
-        });
-        Handlebars.registerHelper("debug", function(optionalValue) {
-          console.log("Current Context");
-          console.log("====================");
-          console.log(this);
-
-          if (optionalValue) {
-            console.log("OptionalValue");
-            console.log("====================");
-            console.log(optionalValue);
-          }
-        });
-        Handlebars.registerHelper('breaklines', function(text) {
-            text = Handlebars.Utils.escapeExpression(text);
-            text = text.replace(/(\r\n|\n|\r)/gm, '<br>');
-            text = text.replace(/ /gm, '&nbsp;');
-            text = text.replace(/	/gm, '&nbsp;&nbsp;&nbsp;&nbsp;');
-            return new Handlebars.SafeString(text);
-        });
-        Handlebars.registerHelper('clean-paragraph', function(text) {
-            text = text.replace(/<p>/gm, '');
-            text = text.replace(/<\/p>/gm, '');
-            return new Handlebars.SafeString(text);
-        });
-        Handlebars.registerHelper('escapeSimpleQuote', function(text) {
-            if(!text) return;
-            var _text = text.replace(/'/g, "\\'");
-            _text = _text.replace(/(\r\n|\n|\r)/gm, '');
-            return _text;
-        });
-        Handlebars.registerHelper('breakComma', function(text) {
-            text = Handlebars.Utils.escapeExpression(text);
-            text = text.replace(/,/g, ',<br>');
-            return new Handlebars.SafeString(text);
-        });
-        Handlebars.registerHelper('modifKind', function(kind) {
-            // https://github.com/Microsoft/TypeScript/blob/master/lib/typescript.d.ts#L62
-            let _kindText = '';
-            switch(kind) {
-                case 112:
-                    _kindText = 'Private';
-                    break;
-                case 113:
-                    _kindText = 'Protected';
-                    break;
-                case 114:
-                    _kindText = 'Public';
-                    break;
-                case 115:
-                    _kindText = 'Static';
-                    break;
-            }
-            return new Handlebars.SafeString(_kindText);
-        });
-        Handlebars.registerHelper('modifIcon', function(kind) {
-            // https://github.com/Microsoft/TypeScript/blob/master/lib/typescript.d.ts#L62
-            let _kindText = '';
-            switch(kind) {
-                case 112:
-                    _kindText = 'lock'; //private
-                    break;
-                case 113:
-                    _kindText = 'lock'; //protected
-                    break;
-                case 115:
-                    _kindText = 'reset'; //static
-                    break;
-                case 84:
-                    _kindText = 'export'; //export
-                    break;
-                default:
-                    _kindText = 'reset';
-                    break;
-            }
-            return _kindText;
-        });
-        /**
-         * Convert {@link MyClass} to [MyClass](http://localhost:8080/classes/MyClass.html)
-         */
-         Handlebars.registerHelper('parseDescription', function(description, depth) {
-             let tagRegExpLight = new RegExp('\\{@link\\s+((?:.|\n)+?)\\}', 'i'),
-                 tagRegExpFull = new RegExp('\\{@link\\s+((?:.|\n)+?)\\}', 'i'),
-                 tagRegExp,
-                 matches,
-                 previousString,
-                 tagInfo = [];
-
-             tagRegExp = (description.indexOf(']{') !== -1) ? tagRegExpFull : tagRegExpLight;
-
-             var processTheLink = function(string, tagInfo, leadingText) {
-                 var leading = extractLeadingText(string, tagInfo.completeTag),
-                     split,
-                     result,
-                     newLink,
-                     rootPath,
-                     stringtoReplace,
-                     anchor = '';
-
-                 split = splitLinkText(tagInfo.text);
-
-                 if (typeof split.linkText !== 'undefined') {
-                     result = $dependenciesEngine.findInCompodoc(split.target);
-                 } else {
-                     let info = tagInfo.text;
-                     if (tagInfo.text.indexOf('#') !== -1) {
-                         anchor = tagInfo.text.substr(tagInfo.text.indexOf('#'), tagInfo.text.length);
-                         info = tagInfo.text.substr(0, tagInfo.text.indexOf('#'));
-                     }
-                     result = $dependenciesEngine.findInCompodoc(info);
-                 }
-
-                 if (result) {
-
-                     if (leadingText) {
-                         stringtoReplace = '[' + leadingText + ']' + tagInfo.completeTag;
-                     }
-                     else if (leading.leadingText !== null) {
-                         stringtoReplace = '[' + leading.leadingText + ']' + tagInfo.completeTag;
-                     } else if (typeof split.linkText !== 'undefined') {
-                         stringtoReplace = tagInfo.completeTag;
-                     } else {
-                         stringtoReplace = tagInfo.completeTag;
-                     }
-
-                     if (result.type === 'class') result.type = 'classe';
-
-                     rootPath = '';
-
-                     switch (depth) {
-                         case 0:
-                             rootPath = './';
-                             break;
-                         case 1:
-                             rootPath = '../';
-                             break;
-                         case 2:
-                             rootPath = '../../';
-                             break;
-                     }
-
-                     let label = result.name;
-                     if (leading.leadingText !== null) {
-                         label = leading.leadingText;
-                     }
-                     if (typeof split.linkText !== 'undefined') {
-                         label = split.linkText;
-                     }
-
-                     newLink = `<a href="${rootPath}${result.type}s/${result.name}.html${anchor}">${label}</a>`;
-                     return string.replace(stringtoReplace, newLink);
-                 } else {
-                     return string;
-                 }
-             }
-
-             function replaceMatch(replacer, tag, match, text, linkText?) {
-                 var matchedTag = {
-                     completeTag: match,
-                     tag: tag,
-                     text: text
-                 };
-                 tagInfo.push(matchedTag);
-
-                 if (linkText) {
-                     return replacer(description, matchedTag, linkText);
-                 } else {
-                     return replacer(description, matchedTag);
-                 }
-             }
-
-             do {
-                 matches = tagRegExp.exec(description);
-                 if (matches) {
-                     previousString = description;
-                     if (matches.length === 2) {
-                         description = replaceMatch(processTheLink, 'link', matches[0], matches[1]);
-                     }
-                     if (matches.length === 3) {
-                         description = replaceMatch(processTheLink, 'link', matches[0], matches[2], matches[1]);
-                     }
-                 }
-             } while (matches && previousString !== description);
-
-             return description;
-         });
-
-        Handlebars.registerHelper('relativeURL', function(currentDepth, context) {
-            let result = '';
-
-            switch (currentDepth) {
-                case 0:
-                    result = './';
-                    break;
-                case 1:
-                    result = '../';
-                    break;
-                case 2:
-                    result = '../../';
-                    break;
-            }
-
-            return result;
-        });
-
-        Handlebars.registerHelper('functionSignature', function(method) {
-            let args = [],
-                configuration = Configuration.getInstance(),
-                angularDocPrefix = prefixOfficialDoc(configuration.mainData.angularVersion);
-            if (method.args) {
-                args = method.args.map(function(arg) {
-                    var _result = $dependenciesEngine.find(arg.type),
-                        _optional = '';
-                    if (arg.optional) {
-                        _optional = '?';
-                    }
-                    if (_result) {
-                        if (_result.source === 'internal') {
-                            let path = _result.data.type;
-                            if (_result.data.type === 'class') path = 'classe';
-                            return `${arg.name}${_optional}: <a href="../${path}s/${_result.data.name}.html">${arg.type}</a>`;
-                        } else {
-                            let path = `https://${angularDocPrefix}angular.io/docs/ts/latest/api/${_result.data.path}`;
-                            return `${arg.name}${_optional}: <a href="${path}" target="_blank">${arg.type}</a>`;
-                        }
-                    } else if (arg.dotDotDotToken) {
-                        return `...${arg.name}: ${arg.type}`;
-                    } else if (arg.function) {
-                        if (arg.function.length > 0) {
-                            let argums = arg.function.map(function(argu) {
-                                    var _result = $dependenciesEngine.find(argu.type),
-                                        _optional = '';
-                                    if (arg.optional) {
-                                        _optional = '?';
-                                    }
-                                    if (_result) {
-                                        if (_result.source === 'internal') {
-                                            let path = _result.data.type;
-                                            if (_result.data.type === 'class') path = 'classe';
-                                            return `${argu.name}${_optional}: <a href="../${path}s/${_result.data.name}.html">${argu.type}</a>`;
-                                        } else {
-                                            let path = `https://${angularDocPrefix}angular.io/docs/ts/latest/api/${_result.data.path}`;
-                                            return `${argu.name}${_optional}: <a href="${path}" target="_blank">${argu.type}</a>`;
-                                        }
-                                    } else if (finderInBasicTypes(argu.type)) {
-                                        let path = `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/${argu.type}`;
-                                        return `${argu.name}${_optional}: <a href="${path}" target="_blank">${argu.type}</a>`;
-                                    } else if (finderInTypeScriptBasicTypes(argu.type)) {
-                                        let path = `https://www.typescriptlang.org/docs/handbook/basic-types.html`;
-                                        return `${argu.name}${_optional}: <a href="${path}" target="_blank">${argu.type}</a>`;
-                                    } else {
-                                        if (argu.name && argu.type) {
-                                            return `${argu.name}${_optional}: ${argu.type}`;
-                                        } else {
-                                            return `${argu.name.text}`;
-                                        }
-                                    }
-                                });
-                            return `${arg.name}${_optional}: (${argums}) => void`;
-                        } else {
-                            return `${arg.name}${_optional}: () => void`;
-                        }
-                    } else if (finderInBasicTypes(arg.type)) {
-                        let path = `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/${arg.type}`;
-                        return `${arg.name}${_optional}: <a href="${path}" target="_blank">${arg.type}</a>`;
-                    } else if (finderInTypeScriptBasicTypes(arg.type)) {
-                        let path = `https://www.typescriptlang.org/docs/handbook/basic-types.html`;
-                        return `${arg.name}${_optional}: <a href="${path}" target="_blank">${arg.type}</a>`;
-                    } else {
-                        return `${arg.name}${_optional}: ${arg.type}`;
-                    }
-                }).join(', ');
-            }
-            if (method.name) {
-                return `${method.name}(${args})`;
-            } else {
-                return `(${args})`;
-            }
-        });
-        Handlebars.registerHelper('jsdoc-returns-comment', function(jsdocTags, options) {
-            var i = 0,
-                len = jsdocTags.length,
-                result;
-            for(i; i<len; i++) {
-                if (jsdocTags[i].tagName) {
-                    if (jsdocTags[i].tagName.text === 'returns') {
-                        result = jsdocTags[i].comment;
-                        break;
-                    }
-                }
-            }
-            return result;
-        });
-        Handlebars.registerHelper('jsdoc-code-example', function(jsdocTags:jsdocTagInterface[], options) {
-            let i = 0,
-                len = jsdocTags.length,
-                tags = [];
-
-            let cleanTag = function(comment) {
-                if (comment.charAt(0) === '*') {
-                    comment = comment.substring(1, comment.length);
-                }
-                if (comment.charAt(0) === ' ') {
-                    comment = comment.substring(1, comment.length);
-                }
-                if (comment.indexOf('<p>') === 0) {
-                    comment = comment.substring(3, comment.length);
-                }
-                if (comment.substr(-1) === '\n') {
-                    comment = comment.substring(0, comment.length - 1);
-                }
-                if (comment.substr(-4) === '</p>') {
-                    comment = comment.substring(0, comment.length - 4);
-                }
-                return comment;
-            }
-
-            let type = 'html';
-
-            if (options.hash.type) {
-                type = options.hash.type;
-            }
-
-            function htmlEntities(str) {
-                return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-            }
-
-            for(i; i<len; i++) {
-                if (jsdocTags[i].tagName) {
-                    if (jsdocTags[i].tagName.text === 'example') {
-                        var tag = {} as jsdocTagInterface;
-                        if (jsdocTags[i].comment) {
-                            if (jsdocTags[i].comment.indexOf('<caption>') !== -1) {
-                                tag.comment = jsdocTags[i].comment.replace(/<caption>/g, '<b><i>').replace(/\/caption>/g, '/b></i>');
-                            } else {
-                                tag.comment = `<pre class="line-numbers"><code class="language-${type}">` + htmlEntities(cleanTag(jsdocTags[i].comment)) + `</code></pre>`;
-                            }
-                        }
-                        tags.push(tag);
-                    }
-                }
-            }
-            if (tags.length > 0) {
-                this.tags = tags;
-                return options.fn(this);
-            }
-        });
-        Handlebars.registerHelper('jsdoc-example', function(jsdocTags:jsdocTagInterface[], options) {
-            let i = 0,
-                len = jsdocTags.length,
-                tags = [];
-
-            for(i; i<len; i++) {
-                if (jsdocTags[i].tagName) {
-                    if (jsdocTags[i].tagName.text === 'example') {
-                        var tag = {} as jsdocTagInterface;
-                        if (jsdocTags[i].comment) {
-                            tag.comment = jsdocTags[i].comment.replace(/<caption>/g, '<b><i>').replace(/\/caption>/g, '/b></i>');
-                        }
-                        tags.push(tag);
-                    }
-                }
-            }
-            if (tags.length > 0) {
-                this.tags = tags;
-                return options.fn(this);
-            }
-        });
-        Handlebars.registerHelper('jsdoc-params', function(jsdocTags:jsdocTagInterface[], options) {
-            var i = 0,
-                len = jsdocTags.length,
-                tags = [];
-            for(i; i<len; i++) {
-                if (jsdocTags[i].tagName) {
-                    if (jsdocTags[i].tagName.text === 'param') {
-                        var tag = {} as jsdocTagInterface;
-                        if (jsdocTags[i].typeExpression && jsdocTags[i].typeExpression.type.kind) {
-                            tag.type = kindToType(jsdocTags[i].typeExpression.type.kind);
-                        }
-                        if (jsdocTags[i].typeExpression && jsdocTags[i].typeExpression.type.name) {
-                            tag.type = jsdocTags[i].typeExpression.type.name.text
-                        } else {
-                            tag.type = jsdocTags[i].type;
-                        }
-                        if (jsdocTags[i].comment) {
-                            tag.comment = jsdocTags[i].comment;
-                        }
-                        if (jsdocTags[i].name) {
-                            if (jsdocTags[i].name.text) {
-                                tag.name = jsdocTags[i].name.text;
-                            } else {
-                                tag.name = jsdocTags[i].name;
-                            }
-                        }
-                        if (jsdocTags[i].optional) {
-                            tag.optional = true;
-                        }
-                        tags.push(tag);
-                    }
-                }
-            }
-            if (tags.length >= 1) {
-                this.tags = tags;
-                return options.fn(this);
-            }
-        });
-        Handlebars.registerHelper('jsdoc-params-valid', function(jsdocTags:jsdocTagInterface[], options) {
-            var i = 0,
-                len = jsdocTags.length,
-                tags = [],
-                valid = false;
-            for(i; i<len; i++) {
-                if (jsdocTags[i].tagName) {
-                    if (jsdocTags[i].tagName.text === 'param') {
-                        valid = true;
-                    }
-                }
-            }
-            if (valid) {
-                return options.fn(this);
-            } else {
-                return options.inverse(this);
-            }
-        });
-        Handlebars.registerHelper('jsdoc-default', function(jsdocTags:jsdocTagInterface[], options) {
-            if (jsdocTags) {
-                var i = 0,
-                    len = jsdocTags.length,
-                    tag = {} as jsdocTagInterface,
-                    defaultValue = false;
-                for(i; i<len; i++) {
-                    if (jsdocTags[i].tagName) {
-                        if (jsdocTags[i].tagName.text === 'default') {
-                            defaultValue = true;
-                            if (jsdocTags[i].typeExpression && jsdocTags[i].typeExpression.type.name) {
-                                tag.type = jsdocTags[i].typeExpression.type.name.text
-                            }
-                            if (jsdocTags[i].comment) {
-                                tag.comment = jsdocTags[i].comment
-                            }
-                            if (jsdocTags[i].name) {
-                                tag.name = jsdocTags[i].name.text;
-                            }
-                        }
-                    }
-                }
-                if (defaultValue) {
-                    this.tag = tag;
-                    return options.fn(this);
-                }
-            }
-        });
-        Handlebars.registerHelper('linkType', function(name, options) {
-            var _result = $dependenciesEngine.find(name),
-                configuration = Configuration.getInstance(),
-                angularDocPrefix = prefixOfficialDoc(configuration.mainData.angularVersion);
-            if (_result) {
-                this.type = {
-                    raw: name
-                }
-                if (_result.source === 'internal') {
-                    if (_result.data.type === 'class') _result.data.type = 'classe';
-                    this.type.href = '../' + _result.data.type + 's/' + _result.data.name + '.html';
-                    if (_result.data.type === 'miscellaneous') {
-                        let mainpage = '';
-                        switch (_result.data.subtype) {
-                            case 'enum':
-                                mainpage = 'enumerations';
-                                break;
-                            case 'function':
-                                mainpage = 'functions';
-                                break;
-                            case 'typealias':
-                                mainpage = 'typealiases';
-                                break;
-                            case 'variable':
-                                mainpage = 'variables';
-                        }
-                        this.type.href = '../' + _result.data.type + '/' + mainpage + '.html#' + _result.data.name;
-                    }
-                    this.type.target = '_self';
-                } else {
-                    this.type.href = `https://${angularDocPrefix}angular.io/docs/ts/latest/api/${_result.data.path}`;
-                    this.type.target = '_blank';
-                }
-
-                return options.fn(this);
-            } else if (finderInBasicTypes(name)) {
-                this.type = {
-                    raw: name
-                };
-                this.type.target = '_blank';
-                this.type.href = `https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/${name}`;
-                return options.fn(this);
-            } else if (finderInTypeScriptBasicTypes(name)) {
-                this.type = {
-                    raw: name
-                };
-                this.type.target = '_blank';
-                this.type.href = 'https://www.typescriptlang.org/docs/handbook/basic-types.html';
-                return options.fn(this);
-            } else {
-                return options.inverse(this);
-            }
-        });
-        Handlebars.registerHelper('indexableSignature', function(method) {
-            const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
-            if (method.name) {
-                return `${method.name}[${args}]`;
-            } else {
-                return `[${args}]`;
-            }
-        });
-        Handlebars.registerHelper('object', function(text) {
-            text = JSON.stringify(text);
-            text = text.replace(/{"/, '{<br>&nbsp;&nbsp;&nbsp;&nbsp;"');
-            text = text.replace(/,"/, ',<br>&nbsp;&nbsp;&nbsp;&nbsp;"');
-            text = text.replace(/}$/, '<br>}');
-            return new Handlebars.SafeString(text);
-        });
-
-        Handlebars.registerHelper('isNotToggle', function(type, options) {
-            let configuration = Configuration.getInstance(),
-                result = configuration.mainData.toggleMenuItems.indexOf(type);
-            if (configuration.mainData.toggleMenuItems.indexOf('all') !== -1) {
-                return options.inverse(this);
-            } else if (result === -1) {
-                return options.fn(this);
-            } else {
-                return options.inverse(this);
-            }
+    private registerHelper(bars, key: string, helper: IHtmlEngineHelper) {
+        Handlebars.registerHelper(key, function() {
+            // tslint:disable-next-line:no-invalid-this
+            return helper.helperFunc.apply(helper, [this, ..._.slice(arguments as any)]);
         });
     }
-    return {
-        init: init
-    }
-})()
+}

--- a/src/app/engines/ngd.engine.ts
+++ b/src/app/engines/ngd.engine.ts
@@ -2,18 +2,21 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as Shelljs from 'shelljs';
 import * as util from 'util';
-
-import { $dependenciesEngine } from './dependencies.engine';
+import * as _ from 'lodash';
 
 import isGlobal from '../../utils/global.path';
+import { DependenciesEngine } from './dependencies.engine';
 
-const ngdT = require('@compodoc/ngd-transformer'),
-      _ = require('lodash');
+const ngdT = require('@compodoc/ngd-transformer');
 
 export class NgdEngine {
-    engine;
-    constructor() {}
-    init(outputpath: string) {
+    public engine;
+
+    constructor(private dependenciesEngine: DependenciesEngine) {
+
+    }
+
+    public init(outputpath: string) {
         this.engine = new ngdT.DotEngine({
             output: outputpath,
             displayLegend: true,
@@ -21,12 +24,13 @@ export class NgdEngine {
             silent: false
         });
     }
-    renderGraph(filepath: string, outputpath: string, type: string, name?: string) {
+
+    public renderGraph(filepath: string, outputpath: string, type: string, name?: string) {
         this.engine.updateOutput(outputpath);
         return new Promise((resolve, reject) => {
             if (type === 'f') {
                 this.engine
-                    .generateGraph([$dependenciesEngine.getRawModule(name)])
+                    .generateGraph([this.dependenciesEngine.getRawModule(name)])
                     .then(file => {
                         resolve();
                     }, error => {
@@ -34,7 +38,7 @@ export class NgdEngine {
                     });
             } else {
                 this.engine
-                    .generateGraph($dependenciesEngine.rawModulesForOverview)
+                    .generateGraph(this.dependenciesEngine.rawModulesForOverview)
                     .then(file => {
                         resolve();
                     }, error => {
@@ -43,7 +47,8 @@ export class NgdEngine {
             }
         });
     }
-    readGraph(filepath: string, name: string) {
+
+    public readGraph(filepath: string, name: string) {
         return new Promise((resolve, reject) => {
             fs.readFile(path.resolve(filepath), 'utf8', (err, data) => {
                if (err) {
@@ -54,4 +59,4 @@ export class NgdEngine {
            });
         });
     }
-};
+}

--- a/src/app/interfaces/jsdoc-tag.interface.ts
+++ b/src/app/interfaces/jsdoc-tag.interface.ts
@@ -10,7 +10,7 @@ export interface jsdocParameterNameInterface {
     text: string;
 }
 
-export interface jsdocTagInterface {
+export interface JsdocTagInterface {
     comment: string;
     name: string;
     tagName: jsdocTagNameInterface;

--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -8,13 +8,13 @@ import { logger } from './logger';
 import { readConfig, handlePath } from './utils/utils';
 import { ExcludeParser } from './utils/exclude.parser';
 
-let pkg = require('../package.json'),
-    program = require('commander'),
-    _ = require('lodash'),
-    os = require('os'),
-    osName = require('os-name'),
-    files = [],
-    cwd = process.cwd();
+const pkg = require('../package.json');
+const program = require('commander');
+const _ = require('lodash');
+const os = require('os');
+const osName = require('os-name');
+const files = [];
+const cwd = process.cwd();
 
 process.setMaxListeners(0);
 
@@ -326,8 +326,8 @@ export class CliApplication extends Application
                         var finder = require('findit')(path.resolve(sourceFolder));
 
                         finder.on('directory', function (dir, stat, stop) {
-                            var base = path.basename(dir);
-                            if (base === '.git' || base === 'node_modules') stop()
+                            let base = path.basename(dir);
+                            if (base === '.git' || base === 'node_modules') stop();
                         });
 
                         finder.on('file', (file, stat) => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,20 +1,20 @@
-let gutil = require('gulp-util')
+let gutil = require('gulp-util');
 let c = gutil.colors;
 let pkg = require('../package.json');
 
 enum LEVEL {
 	INFO,
 	DEBUG,
-    ERROR,
-    WARN
+	ERROR,
+	WARN
 }
 
 class Logger {
 
-	name;
-	logger;
-	version;
-	silent;
+	public name;
+	public logger;
+	public version;
+	public silent;
 
 	constructor() {
 		this.name = pkg.name;
@@ -23,29 +23,29 @@ class Logger {
 		this.silent = true;
 	}
 
-	info(...args) {
-		if(!this.silent) return;
+	public info(...args) {
+		if (!this.silent) { return; }
 		this.logger(
 			this.format(LEVEL.INFO, ...args)
 		);
 	}
 
-	error(...args) {
-		if(!this.silent) return;
+	public error(...args) {
+		if (!this.silent) { return; }
 		this.logger(
 			this.format(LEVEL.ERROR, ...args)
 		);
 	}
 
-    warn(...args) {
-		if(!this.silent) return;
+	public warn(...args) {
+		if (!this.silent) { return; }
 		this.logger(
 			this.format(LEVEL.WARN, ...args)
 		);
 	}
 
-	debug(...args) {
-		if(!this.silent) return;
+	public debug(...args) {
+		if (!this.silent) { return; }
 		this.logger(
 			this.format(LEVEL.DEBUG, ...args)
 		);
@@ -53,17 +53,17 @@ class Logger {
 
 	private format(level, ...args) {
 
-		let pad = (s, l, c='') => {
-			return s + Array( Math.max(0, l - s.length + 1)).join( c )
+		let pad = (s, l, z = '') => {
+			return s + Array(Math.max(0, l - s.length + 1)).join(z);
 		};
 
 		let msg = args.join(' ');
-		if(args.length > 1) {
-			msg = `${ pad(args.shift(), 15, ' ') }: ${ args.join(' ') }`;
+		if (args.length > 1) {
+			msg = `${pad(args.shift(), 15, ' ')}: ${args.join(' ')}`;
 		}
 
 
-		switch(level) {
+		switch (level) {
 			case LEVEL.INFO:
 				msg = c.green(msg);
 				break;
@@ -72,7 +72,7 @@ class Logger {
 				msg = c.cyan(msg);
 				break;
 
-            case LEVEL.WARN:
+			case LEVEL.WARN:
 				msg = c.yellow(msg);
 				break;
 

--- a/test/saucelabs/mocha.spec.ts
+++ b/test/saucelabs/mocha.spec.ts
@@ -1,124 +1,125 @@
 // RUN webdriver-manager start --standalone & npm run test:simple-doc before starting local test
-var expect = require('chai').expect,
-    fs = require('fs'),
-    webdriver = require('selenium-webdriver'),
-    request = require('request'),
-    username = process.env.SAUCE_USERNAME,
-    accessKey = process.env.SAUCE_ACCESS_KEY,
-    capabilities: any = {
-        'platform': 'WIN7'
-    },
-    server = '',
-    startDriver = function(cb, pageUrl) {
-        if (process.env.MODE_LOCAL === '0') {
-            capabilities.username = username;
-            capabilities.accessKey = accessKey;
-            capabilities['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;
-            capabilities.name = 'Compodoc test';
-            capabilities.public = true;
-            capabilities.build = process.env.TRAVIS_BUILD_NUMBER;
-            server = 'http://' + username + ':' + accessKey + '@ondemand.saucelabs.com:80/wd/hub';
+const expect = require('chai').expect;
+const fs = require('fs');
+const webdriver = require('selenium-webdriver');
+const request = require('request');
+
+let username = process.env.SAUCE_USERNAME;
+let accessKey = process.env.SAUCE_ACCESS_KEY;
+let capabilities: any = {
+    'platform': 'WIN7'
+};
+let server = '';
+let startDriver = function (cb, pageUrl) {
+    if (process.env.MODE_LOCAL === '0') {
+        capabilities.username = username;
+        capabilities.accessKey = accessKey;
+        capabilities['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;
+        capabilities.name = 'Compodoc test';
+        capabilities.public = true;
+        capabilities.build = process.env.TRAVIS_BUILD_NUMBER;
+        server = 'http://' + username + ':' + accessKey + '@ondemand.saucelabs.com:80/wd/hub';
+    }
+    if (process.env.MODE_LOCAL === '1') {
+        capabilities.platform = 'Linux';
+        server = 'http://localhost:4444/wd/hub';
+    }
+
+    driver = new webdriver.Builder()
+        .withCapabilities(capabilities)
+        .usingServer(server)
+        .build();
+
+    driver.getSession().then(function (sessionid) {
+        driver.sessionID = sessionid.id_;
+    });
+
+    driver.get(pageUrl).then(function () {
+        cb();
+    });
+};
+let handleStatus = function (tests) {
+    var status = false;
+    for (var i = 0; i < tests.length; i++) {
+        if (tests[i].state === 'passed') {
+            status = true;
         }
-        if (process.env.MODE_LOCAL === '1') {
-            capabilities.platform = 'Linux';
-            server = 'http://localhost:4444/wd/hub';
-        }
-
-        driver = new webdriver.Builder()
-            .withCapabilities(capabilities)
-            .usingServer(server)
-            .build();
-
-        driver.getSession().then(function(sessionid) {
-            driver.sessionID = sessionid.id_;
-        });
-
-        driver.get(pageUrl).then(function() {
-            cb();
-        });
-    },
-    handleStatus = function(tests) {
-        var status = false;
-        for (var i = 0; i < tests.length; i++) {
-            if (tests[i].state === 'passed') {
-                status = true;
+    }
+    return status;
+};
+let writeScreenshot = function (data, name) {
+    fs.writeFile('out.png', data, 'base64', function (err) {
+        if (err) console.log(err);
+    });
+};
+let endTests = function (context, cb) {
+    if (process.env.MODE_LOCAL === '0') {
+        var result = handleStatus(context.test.parent.tests);
+        request({
+            method: 'PUT',
+            uri: `https://${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}@saucelabs.com/rest/v1/${process.env.SAUCE_USERNAME}/jobs/${driver.sessionID}`,
+            json: {
+                passed: result
             }
-        }
-        return status;
-    },
-    writeScreenshot = function(data, name) {
-        fs.writeFile('out.png', data, 'base64', function(err) {
-            if (err) console.log(err);
-        });
-    },
-    endTests = function(context, cb) {
-        if (process.env.MODE_LOCAL === '0') {
-            var result = handleStatus(context.test.parent.tests);
-            request({
-                method: 'PUT',
-                uri: `https://${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}@saucelabs.com/rest/v1/${process.env.SAUCE_USERNAME}/jobs/${driver.sessionID}`,
-                json: {
-              		passed: result
-            	}
-            }, function(error, response, body) {
-                driver.quit().then(cb);
-            });
-        } else {
+        }, function (error, response, body) {
             driver.quit().then(cb);
-        }
-    },
-    testSearchBarWithResults = function(cb) {
-        var searchBox
-        driver
-            .findElements(webdriver.By.xpath("//div[@id='book-search-input']/input"))
-            .then(function(elems) {
-                searchBox = elems[1]; //First one is the mobile one hidden;
-                searchBox.sendKeys('exampleInput');
-                searchBox.getAttribute('value').then(function(value) {
-                    expect(value).to.equal('exampleInput');
+        });
+    } else {
+        driver.quit().then(cb);
+    }
+};
+let testSearchBarWithResults = function (cb) {
+    var searchBox
+    driver
+        .findElements(webdriver.By.xpath("//div[@id='book-search-input']/input"))
+        .then(function (elems) {
+            searchBox = elems[1]; // First one is the mobile one hidden;
+            searchBox.sendKeys('exampleInput');
+            searchBox.getAttribute('value').then(function (value) {
+                expect(value).to.equal('exampleInput');
 
-                    /*driver.takeScreenshot().then(function (data) {
-                        writeScreenshot(data, 'test.png');
-                    });*/
+                /*driver.takeScreenshot().then(function (data) {
+                    writeScreenshot(data, 'test.png');
+                });*/
 
-                    driver.sleep(2000);
+                driver.sleep(2000);
 
-                    driver
-                        .findElements(webdriver.By.className('search-results-item'))
-                        .then(function(elems) {
-                            expect(elems.length).to.equal(1);
-                            cb();
-                        });
-                });
+                driver
+                    .findElements(webdriver.By.className('search-results-item'))
+                    .then(function (elems) {
+                        expect(elems.length).to.equal(1);
+                        cb();
+                    });
             });
-    },
-    testSearchBarWithNoResults = function(cb) {
-        var searchBox
-        driver
-            .findElements(webdriver.By.xpath("//div[@id='book-search-input']/input"))
-            .then(function(elems) {
-                searchBox = elems[1]; //First one is the mobile one hidden;
-                searchBox.clear();
-                searchBox.sendKeys('waza');
-                searchBox.getAttribute('value').then(function(value) {
-                    expect(value).to.equal('waza');
+        });
+};
+let testSearchBarWithNoResults = function (cb) {
+    let searchBox;
+    driver
+        .findElements(webdriver.By.xpath("//div[@id='book-search-input']/input"))
+        .then(function (elems) {
+            searchBox = elems[1]; // First one is the mobile one hidden;
+            searchBox.clear();
+            searchBox.sendKeys('waza');
+            searchBox.getAttribute('value').then(function (value) {
+                expect(value).to.equal('waza');
 
-                    driver.sleep(2000);
+                driver.sleep(2000);
 
-                    driver
-                        .findElements(webdriver.By.className('search-results-item'))
-                        .then(function(elems) {
-                            expect(elems.length).to.equal(0);
-                            cb();
-                        });
-                });
+                driver
+                    .findElements(webdriver.By.className('search-results-item'))
+                    .then(function (elems1) {
+                        expect(elems1.length).to.equal(0);
+                        cb();
+                    });
             });
-    },
-    driver;
+        });
+};
+let driver;
 
-describe('WIN7 | Chrome | Compodoc page', function() {
+describe('WIN7 | Chrome | Compodoc page', function () {
 
-    before(function(done) {
+    before(function (done) {
         capabilities.browserName = 'chrome';
         capabilities.version = '56';
 
@@ -127,17 +128,17 @@ describe('WIN7 | Chrome | Compodoc page', function() {
 
     // Test search bar
 
-    it('should have a search bar, and handle results', function(done) {
+    it('should have a search bar, and handle results', function (done) {
         testSearchBarWithResults(done);
     });
 
-    it('should have a search bar, and handle results empty', function(done) {
+    it('should have a search bar, and handle results empty', function (done) {
         testSearchBarWithNoResults(done);
     });
 
     // TODO : test routing
 
-    after(function(done) {
+    after(function (done) {
         endTests(this, done);
     });
 });
@@ -222,9 +223,9 @@ describe('WIN7 | IE | Compodoc page', function() {
     });
 });*/
 
-describe('Linux | Firefox | Compodoc page', function() {
+describe('Linux | Firefox | Compodoc page', function () {
 
-    before(function(done) {
+    before(function (done) {
         capabilities.platform = 'linux';
         capabilities.browserName = 'firefox';
         capabilities.version = '45';
@@ -234,24 +235,24 @@ describe('Linux | Firefox | Compodoc page', function() {
 
     // Test search bar
 
-    it('should have a search bar, and handle results', function(done) {
+    it('should have a search bar, and handle results', function (done) {
         testSearchBarWithResults(done);
     });
 
-    it('should have a search bar, and handle results empty', function(done) {
+    it('should have a search bar, and handle results empty', function (done) {
         testSearchBarWithNoResults(done);
     });
 
     // TODO : test routing
 
-    after(function(done) {
+    after(function (done) {
         endTests(this, done);
     });
 });
 
-describe('Linux | Chrome | Compodoc page', function() {
+describe('Linux | Chrome | Compodoc page', function () {
 
-    before(function(done) {
+    before(function (done) {
         capabilities.platform = 'linux';
         capabilities.browserName = 'chrome';
         capabilities.version = '48';
@@ -261,17 +262,17 @@ describe('Linux | Chrome | Compodoc page', function() {
 
     // Test search bar
 
-    it('should have a search bar, and handle results', function(done) {
+    it('should have a search bar, and handle results', function (done) {
         testSearchBarWithResults(done);
     });
 
-    it('should have a search bar, and handle results empty', function(done) {
+    it('should have a search bar, and handle results empty', function (done) {
         testSearchBarWithNoResults(done);
     });
 
     // TODO : test routing
 
-    after(function(done) {
+    after(function (done) {
         endTests(this, done);
     });
 });
@@ -305,9 +306,9 @@ describe('Mac | Firefox | Compodoc page', function() {
 });
 */
 
-describe('Mac | Chrome | Compodoc page', function() {
+describe('Mac | Chrome | Compodoc page', function () {
 
-    before(function(done) {
+    before(function (done) {
         capabilities.platform = 'Mac 10.11';
         capabilities.browserName = 'chrome';
         capabilities.version = '56';
@@ -317,17 +318,17 @@ describe('Mac | Chrome | Compodoc page', function() {
 
     // Test search bar
 
-    it('should have a search bar, and handle results', function(done) {
+    it('should have a search bar, and handle results', function (done) {
         testSearchBarWithResults(done);
     });
 
-    it('should have a search bar, and handle results empty', function(done) {
+    it('should have a search bar, and handle results empty', function (done) {
         testSearchBarWithNoResults(done);
     });
 
     // TODO : test routing
 
-    after(function(done) {
+    after(function (done) {
         endTests(this, done);
     });
 });

--- a/test/src/cli/cli-typedoc-examples.spec.ts
+++ b/test/src/cli/cli-typedoc-examples.spec.ts
@@ -1,14 +1,14 @@
 import * as chai from 'chai';
 import {temporaryDir, shell, pkg, exists, exec, read, shellAsync} from '../helpers';
-const expect = chai.expect,
-      tmp = temporaryDir(),
-      tsconfigPath = require.resolve('../../../tsconfig.json'),
-      env = Object.freeze({TS_NODE_PROJECT: tsconfigPath, MODE:'TESTING'});
+const expect = chai.expect;
+const tmp = temporaryDir();
+const tsconfigPath = require.resolve('../../../tsconfig.json');
+const env = Object.freeze({TS_NODE_PROJECT: tsconfigPath, MODE:'TESTING'});
 
 describe('CLI generation - TypeDoc examples', () => {
 
       let stdoutString = null;
-      before(function (done) {
+      before((done) => {
           let ls = shell('node', [
               './bin/index-cli.js',
               '-p', './test/src/typedoc-examples/tsconfig.json'], { env});
@@ -20,7 +20,7 @@ describe('CLI generation - TypeDoc examples', () => {
           stdoutString = ls.stdout.toString();
           done();
       });
-      //after(() => tmp.clean('documentation'));
+      // after(() => tmp.clean('documentation'));
 
       it('should display generated message', () => {
           expect(stdoutString).to.contain('Documentation generated');
@@ -28,9 +28,9 @@ describe('CLI generation - TypeDoc examples', () => {
 
       it('interfaces - INameInterface', () => {
           const file = read(`documentation/interfaces/INameInterface.html`);
-          expect(file).to.contain('This is a simple interface.');
-          expect(file).to.contain('This is a interface function of INameInterface.');
-          expect(file).to.contain('This is a interface member of INameInterface.');
+          expect(file, 'Did not contain class comment').to.contain('This is a simple interface.');
+          expect(file, 'Did not contain function commment').to.contain('This is a interface function of INameInterface.');
+          expect(file, 'Did not contain member comment').to.contain('This is a interface member of INameInterface.');
       });
 
       it('interfaces - IPrintNameInterface', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -1,11 +1,6 @@
 {
     "rules": {
-        "align": [
-            true,
-            "parameters",
-            "arguments",
-            "statements"
-        ],
+        "align": false,
         "ban": [
             true,
             ["_", "each"],
@@ -19,7 +14,7 @@
         ],
         "curly": true,
         "eofline": false,
-        "forin": true,
+        "forin": false,
         "indent": [
             true,
             4
@@ -31,12 +26,7 @@
             140
         ],
         "member-access": true,
-        "member-ordering": [
-            true,
-            {
-                "order": "fields-first"
-            }
-        ],
+        "member-ordering": false,
         "new-parens": true,
         "no-angle-bracket-type-assertion": true,
         "no-any": false,
@@ -86,7 +76,7 @@
         ],
         "radix": true,
         "semicolon": [true, "always"],
-        "switch-default": true,
+        "switch-default": false,
         "trailing-comma": [false],
         "triple-equals": [
             true,


### PR DESCRIPTION
Each of the HandleBar helpers has been split into its own file and lint'ed, which should make it easier to unit-test if the need ever comes.

Configuration has been made non-singleton, so if one ever uses compodoc directly from node, it should be possible to have multiple instances of compodoc running without interfering with each other.

Also, im discarding dist\index-cli.js & dist\index.js every time, let me know if that's wrong, thanks :)