### PR TITLE
fix: remove deprecation warning when installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "handlebars": "^4.0.10",
     "html-entities": "^1.2.1",
     "json5": "^0.5.1",
-    "live-server": "1.1.0",
+    "live-server": "^1.2.0",
     "lodash": "^4.17.3",
     "lunr": "1.0.0",
     "marked": "^0.3.6",


### PR DESCRIPTION
Currently when installing you get `npm WARN deprecated node-uuid@1.4.8: Use uuid module instead`, updating to the latest version of live-server should fix the issue (I also unpinned it, I'm not too sure if there was a specific reason for pinning it?)