### PR TITLE
fix(tests): Fixed tests on Windows

### DIFF
--- a/src/utils/include-parser.util.ts
+++ b/src/utils/include-parser.util.ts
@@ -10,19 +10,17 @@ export class IncludeParserUtil {
     public init(include: string[], cwd: string) {
         this._include = include;
         this._cwd = cwd;
-        let i = 0;
-        let len = include.length;
-
-        for (i; i < len; i++) {
-            this._globFiles = [...this._globFiles, ...glob.sync(include[i], { cwd: this._cwd })];
-        }
+        
+        this._globFiles = include
+            .map((includeRule) => glob.sync(includeRule, { cwd: this._cwd }).map((filePath) => filePath.replace(/\//, path.sep)))
+            .reduce((allFiles, globs) => [...allFiles, ...globs], []);
     }
 
     public testFile(file: string): boolean {
         let i = 0;
         let len = this._include.length;
         let fileBasename = path.basename(file);
-        let fileNameInCwd = file.replace(this._cwd + path.sep, '');
+        let fileNameInCwd = file.replace(this._cwd + path.sep, '').replace(/\//,path.sep);
         let result = false;
 
         if (path.sep === '\\') {

--- a/test/src/cli/cli-generation.spec.ts
+++ b/test/src/cli/cli-generation.spec.ts
@@ -251,8 +251,7 @@ describe('CLI simple generation', () => {
         before((done) => {
             tmp.create();
 
-            let pwd = shell('pwd');
-            actualDir = pwd.stdout.toString();
+            actualDir = process.cwd();
 
             actualDir = actualDir.replace(' ', '');
             actualDir = actualDir.replace('\n', '');
@@ -610,11 +609,16 @@ describe('CLI simple generation', () => {
                 '-s',
                 '-r',
                 '-r', port,
-                '-d', './' + tmp.name + '/'], { env, timeout: 5000});
+                '-d', './' + tmp.name + '/'], { env, timeout: 20000});
 
             if (ls.stderr.toString() !== '') {
-                console.error(`shell error: ${ls.stderr.toString()}`);
-                done('error');
+                done(new Error(`shell error: ${ls.stderr.toString()}`));
+                return;
+            }
+            
+            if (ls.signal === 'SIGTERM') {
+                done(new Error('Process timeout'));
+                return;
             }
             stdoutString = ls.stdout.toString();
             done();


### PR DESCRIPTION
Why:

* Some tests were not passing because of path separator
* Other tests were failling because of process timeout

This change addresses the need by:

* Normalizing the paths in IncludeParser
* Increased timeout (5s to 20s)