### PR TITLE
fix(class-helper#visitType) Fix union type and composed type

### DIFF
--- a/src/app/compiler/deps/helpers/class-helper-spec/class-helper.visitType.spec.ts
+++ b/src/app/compiler/deps/helpers/class-helper-spec/class-helper.visitType.spec.ts
@@ -29,5 +29,16 @@ describe(ClassHelper.name + ' visitType', () => {
 
             expect(helperResult).to.equal('SomeType<number>');
         });
+        
+        it('should convert a type with a union argument', () => {
+            let numberType = ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+            let stringType = ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+            let genericType = ts.createTypeReferenceNode('SomeType', [numberType, stringType]);
+            let result = ts.createCallSignature([], [], genericType);
+
+            let helperResult = classHelper.visitType(result);
+
+            expect(helperResult).to.equal('SomeType<number | string>');
+        });
     });
 });

--- a/src/utils/kind-to-type.ts
+++ b/src/utils/kind-to-type.ts
@@ -34,6 +34,9 @@ export function kindToType(kind: number): string {
         case ts.SyntaxKind.NeverKeyword:
             _type = 'never';
             break;
+        case ts.SyntaxKind.UndefinedKeyword:
+            _type = 'undefined';
+            break;
         case ts.SyntaxKind.ObjectKeyword:
         case ts.SyntaxKind.ObjectLiteralExpression:
             _type = 'object';


### PR DESCRIPTION
Why:

* Composed types were not rendered correctly sometimes
* Union types were being translated to undefined or empty

This change addresses the need by:

* Refactored visitType
* Included spec for union type

Before the fix:
![compodoc](https://user-images.githubusercontent.com/1570567/32226900-16ffb402-be4a-11e7-8312-c4ce01b13191.png)

![compodoc-2](https://user-images.githubusercontent.com/1570567/32226918-229fc054-be4a-11e7-9a3b-411eeedca5eb.png)

After the fix:

![compodoc-fix](https://user-images.githubusercontent.com/1570567/32226929-27bf3bdc-be4a-11e7-92c5-055eb951e8b3.png)

![compodoc-fix-2](https://user-images.githubusercontent.com/1570567/32226935-2c88351a-be4a-11e7-9ba1-bcc347b0c2bc.PNG)


