### PR TITLE
fix:--assetsFolder uses only last directory name on copy

### DIFF
--- a/src/app/application.ts
+++ b/src/app/application.ts
@@ -1570,9 +1570,12 @@ export class Application {
         if (!this.fileEngine.existsSync(this.configuration.mainData.assetsFolder)) {
             logger.error(`Provided assets folder ${this.configuration.mainData.assetsFolder} did not exist`);
         } else {
+            const destination = path.join(
+                                    this.configuration.mainData.output,
+                                    path.basename(this.configuration.mainData.assetsFolder));
             fs.copy(
                 path.resolve(this.configuration.mainData.assetsFolder),
-                path.resolve(this.configuration.mainData.output + path.sep + this.configuration.mainData.assetsFolder), (err) => {
+                path.resolve(destination), (err) => {
                     if (err) {
                         logger.error('Error during resources copy ', err);
                     }

--- a/test/src/cli/cli-generation.spec.ts
+++ b/test/src/cli/cli-generation.spec.ts
@@ -332,6 +332,30 @@ describe('CLI simple generation', () => {
         });
     });
 
+    describe('when passing a deep path on a flag', () => {
+
+        before(function (done) {
+            tmp.create();
+            let ls = shell('node', [
+                './bin/index-cli.js',
+                '-p', './test/src/sample-files/tsconfig.simple.json',
+                '-d', './' + tmp.name + '/',
+                '-a', './test/src/todomvc-ng2/screenshots/actions'], { env});
+
+            if (ls.stderr.toString() !== '') {
+                console.error(`shell error: ${ls.stderr.toString()}`);
+                done('error');
+            }
+            done();
+        });
+        after(() => tmp.clean());
+
+        it('should flatten the path to the deeper dirname', () => {
+            const isFolderExists = exists(`${tmp.name}/actions`);
+            expect(isFolderExists).to.be.true;
+        });
+    });
+
     describe('when generation with d flag and src arg', () => {
 
         let stdoutString = undefined;


### PR DESCRIPTION
It certanly brokes previous behaviour, but I would expect --assetsFolder to copy only the **last** directory on the passed path.

Current behaviour is a bit buggy when passing relative directories:
```bash
/home/user/project $ ./node_modules/.bin/compodoc -p tsconfig.json --assetsFolder ../project2/assets
```
That command will generate a copy of _/home/user/project2/assets_ on _/home/user/project/project2/assets_ and not on _/home/user/project /documentation/ as it could be expected.

This PR will use path.basename before copying the directory; so previoud command will generate a folder on _/home/user/project/documentation/assets_ with the content fount on _/home/user/project/project2/assets_. 








