### PR TITLE
refactor: prepareExternalIncludes parses children recursively

### DIFF
--- a/src/app/engines/html-engine-helpers/parse-description.helper.ts
+++ b/src/app/engines/html-engine-helpers/parse-description.helper.ts
@@ -62,10 +62,11 @@ export class ParseDescriptionHelper implements IHtmlEngineHelper {
                         rootPath = './';
                         break;
                     case 1:
-                        rootPath = '../';
-                        break;
                     case 2:
-                        rootPath = '../../';
+                    case 3:
+                    case 4:
+                    case 5:
+                        rootPath = '../'.repeat(depth);
                         break;
                 }
 

--- a/src/app/engines/html-engine-helpers/relative-url.helper.ts
+++ b/src/app/engines/html-engine-helpers/relative-url.helper.ts
@@ -6,9 +6,11 @@ export class RelativeURLHelper implements IHtmlEngineHelper {
             case 0:
                 return './';
             case 1:
-                return '../';
             case 2:
-                return '../../';
+            case 3:
+            case 4:
+            case 5:
+                return '../'.repeat(currentDepth);
         }
 
         return '';

--- a/src/resources/js/search/search.js
+++ b/src/resources/js/search/search.js
@@ -58,10 +58,11 @@
                     link = './';
                     break;
                 case 1:
-                    link = '../';
-                    break;
                 case 2:
-                    link = '../../';
+                case 3:
+                case 4:
+                case 5:
+                    link = '../'.repeat(currentDepth);
                     break;
             }
 

--- a/src/resources/styles/compodoc.css
+++ b/src/resources/styles/compodoc.css
@@ -287,9 +287,22 @@ h6 {
     padding-left: 20px;
 }
 
-.menu ul.list li.for-chapter {
+.menu ul.list li.for-chapter2 {
     padding-left: 20px;
 }
+
+.menu ul.list li.for-chapter3 {
+  padding-left: 40px;
+}
+
+.menu ul.list li.for-chapter4 {
+  padding-left: 60px;
+}
+
+.menu ul.list li.for-chapter5 {
+  padding-left: 80px;
+}
+
 
 .menu ul.list li.chapter .simple {
     padding: 10px 15px;

--- a/src/templates/partials/menu.hbs
+++ b/src/templates/partials/menu.hbs
@@ -72,7 +72,7 @@
                     id="xs-additional-pages"
                 {{/compare}}>
                 {{#each additionalPages}}
-                    <li class="link {{#compare depth "===" 2 }}for-chapter{{/compare}}">
+                    <li class="link {{#compare depth ">" 1 }}for-chapter{{depth}}{{/compare}}">
                         <a href="{{relativeURL ../depth 'additional-page'}}{{path}}/{{filename}}.html" {{#compare ../id "===" id }} data-type="entity-link" class="active" {{/compare}}>{{ name }}</a>
                     </li>
                 {{/each}}

--- a/test/src/cli/cli-additional.spec.ts
+++ b/test/src/cli/cli-additional.spec.ts
@@ -32,7 +32,6 @@ describe('CLI Additional documentation', () => {
     after(() => tmp.clean());
 
     it('it should have a menu with links', () => {
-
         expect(fooIndexFile.indexOf('<a href="additional-documentation/big-introduction') > -1).to.be.true;
         expect(fooIndexFile.indexOf('Big Introduction') > -1).to.be.true;
     });
@@ -49,5 +48,30 @@ describe('CLI Additional documentation', () => {
     it('should have generated README file in index.html', () => {
         const file = read(`${tmp.name}/additional-documentation/edition/edition-of-a-todo.html`);
         expect(file).to.contain('screenshots/actions/edition.png');
+    });
+
+    it('should contain up to 5 level of depth', () => {
+
+      expect(fooIndexFile.indexOf('for-chapter2') > -1).to.be.true;
+      expect(fooIndexFile.indexOf('for-chapter3') > -1).to.be.true;
+      expect(fooIndexFile.indexOf('for-chapter4') > -1).to.be.true;
+      expect(fooIndexFile.indexOf('for-chapter5') > -1).to.be.true;
+
+      expect(fooIndexFile.indexOf('for-chapter6') > -1).to.be.false;
+
+    });
+
+    it('should generate every link containing its parent reference', () => {
+      [
+        '<a href="additional-documentation/edition/edition-of-a-todo/edit-level3.html',
+        '<a href="additional-documentation/edition/edition-of-a-todo/edit-level3/edit-level4.html',
+        '<a href="additional-documentation/edition/edition-of-a-todo/edit-level3/edit-level4/edit-level5.html',
+      ].map(linkRef =>
+        expect(fooIndexFile.indexOf(linkRef) > -1).to.be.true
+      );
+
+      expect(fooIndexFile.indexOf(
+        '<a href="additional-documentation/edition/edition-of-a-todo/edit-level3/edit-level4/edit-level5/edit-level6.html'
+      ) > -1).to.be.false;
     });
 });

--- a/test/src/todomvc-ng2/additional-doc/edition/level3.md
+++ b/test/src/todomvc-ng2/additional-doc/edition/level3.md
@@ -1,0 +1,1 @@
+## Sample Edition Level 3

--- a/test/src/todomvc-ng2/additional-doc/edition/level4.md
+++ b/test/src/todomvc-ng2/additional-doc/edition/level4.md
@@ -1,0 +1,1 @@
+## Sample Edition Level 4

--- a/test/src/todomvc-ng2/additional-doc/edition/level5.md
+++ b/test/src/todomvc-ng2/additional-doc/edition/level5.md
@@ -1,0 +1,1 @@
+## Sample Edition Level 5

--- a/test/src/todomvc-ng2/additional-doc/edition/level6.md
+++ b/test/src/todomvc-ng2/additional-doc/edition/level6.md
@@ -1,0 +1,1 @@
+## Sample Edition Level 6

--- a/test/src/todomvc-ng2/additional-doc/summary.json
+++ b/test/src/todomvc-ng2/additional-doc/summary.json
@@ -1,5 +1,4 @@
-[
-    {
+[{
         "title": "Big Introduction",
         "file": "introduction.md"
     },
@@ -8,9 +7,33 @@
         "file": "edition.md",
         "children": [
             {
-                "title": "Edition of a todo",
-                "file": "edition/edition.md"
+            "title": "Edition of a todo",
+            "file": "edition/edition.md",
+            "children": [
+                {
+                "title": "edit-level3",
+                "file": "edition/level3.md",
+                "children": [
+                    {
+                    "title": "edit-level4",
+                    "file": "edition/level4.md",
+                    "children": [
+                        {
+                        "title": "edit-level5",
+                        "file": "edition/level5.md",
+                        "children": [
+                            {
+                            "title": "edit-level6",
+                            "file": "edition/level6.md"
+                        }
+                    ]
+                    }
+                ]
+                }
+            ]
             }
         ]
+        }
+    ]
     }
 ]


### PR DESCRIPTION
Right now, only 2 levels of depth are supported.

I have had to refactor a little bit the _prepareExternalIncludes_ method, and have decided to limit in *5* levels of depth (which applies across the application, allthought it only affects on the "--includes" folder (I think).

I have added a logger.error whenever someone tries to set more than 5 levels of depth on a summary.json file.

