### PR TITLE
Removed relative URL helper function from logo img tag

### DIFF
--- a/src/templates/partials/menu.hbs
+++ b/src/templates/partials/menu.hbs
@@ -359,12 +359,12 @@
                 Documentation generated using <a href="https://compodoc.github.io/website/" target="_blank">
                     {{#if theme }}
                         {{#compare theme "indexof" 'readthedocs,vagrant,postmark'}}
-                            <img src="./images/compodoc-vectorise-inverted.svg" class="img-responsive">
+                            <img src="{{relativeURL depth 'logo'}}images/compodoc-vectorise-inverted.svg" class="img-responsive">
                         {{else}}
-                            <img src="./images/compodoc-vectorise.svg" class="img-responsive">
+                            <img src="{{relativeURL depth 'logo'}}images/compodoc-vectorise.svg" class="img-responsive">
                         {{/compare}}
                     {{else}}
-                    <img src="./images/compodoc-vectorise.svg" class="img-responsive">
+                    <img src="{{relativeURL depth 'logo'}}images/compodoc-vectorise.svg" class="img-responsive">
                     {{/if}}
                 </a>
         </li>

--- a/src/templates/partials/menu.hbs
+++ b/src/templates/partials/menu.hbs
@@ -359,12 +359,12 @@
                 Documentation generated using <a href="https://compodoc.github.io/website/" target="_blank">
                     {{#if theme }}
                         {{#compare theme "indexof" 'readthedocs,vagrant,postmark'}}
-                            <img src="{{relativeURL depth 'logo'}}/images/compodoc-vectorise-inverted.svg" class="img-responsive">
+                            <img src="./images/compodoc-vectorise-inverted.svg" class="img-responsive">
                         {{else}}
-                            <img src="{{relativeURL depth 'logo'}}/images/compodoc-vectorise.svg" class="img-responsive">
+                            <img src="./images/compodoc-vectorise.svg" class="img-responsive">
                         {{/compare}}
                     {{else}}
-                    <img src="{{relativeURL depth 'logo'}}/images/compodoc-vectorise.svg" class="img-responsive">
+                    <img src="./images/compodoc-vectorise.svg" class="img-responsive">
                     {{/if}}
                 </a>
         </li>


### PR DESCRIPTION
This causes problems when hosting as the URL will resolve to ".//images/compodoc-vectorise-inverted.svg". It appears the prepending forward slash is not necessary (as the relativeURL function is suffixed with a "/")