### PR TITLE
fix(UI): Address double-scrollbar on example tabs for directive, pipe, and injectable

### DIFF
--- a/src/resources/styles/compodoc.css
+++ b/src/resources/styles/compodoc.css
@@ -202,7 +202,7 @@ a[href] {
     height: 100%;
 }
 
-.content-data iframe {
+.content-data .exampleContainer {
     height: 100%;
     width: 100%;
 }

--- a/src/templates/partials/component.hbs
+++ b/src/templates/partials/component.hbs
@@ -59,7 +59,7 @@
     {{#isTabEnabled navTabs "example"}}
     <div class="tab-pane fade {{#isInitialTab navTabs "example"}}active in{{/isInitialTab}}" id="c-example">
         {{#each component.exampleUrls}}
-            <iframe src="{{this}}">
+            <iframe class="exampleContainer" src="{{this}}">
                 <p>Your browser does not support iframes.</p>
             </iframe>
         {{/each}}

--- a/src/templates/partials/directive.hbs
+++ b/src/templates/partials/directive.hbs
@@ -138,7 +138,7 @@
     {{#isTabEnabled navTabs "example"}}
     <div class="tab-pane fade {{#isInitialTab navTabs "example"}}active in{{/isInitialTab}}" id="c-example">
         {{#each directive.exampleUrls}}
-            <iframe src="{{this}}" style="height: 100vh; width: 100%;">
+            <iframe class="exampleContainer" src="{{this}}">
                 <p>Your browser does not support iframes.</p>
             </iframe>
         {{/each}}

--- a/src/templates/partials/injectable.hbs
+++ b/src/templates/partials/injectable.hbs
@@ -82,7 +82,7 @@
     {{#isTabEnabled navTabs "example"}}
     <div class="tab-pane fade {{#isInitialTab navTabs "example"}}active in{{/isInitialTab}}" id="c-example">
         {{#each injectable.exampleUrls}}
-            <iframe src="{{this}}" style="height: 100vh; width: 100%;">
+            <iframe class="exampleContainer" src="{{this}}">
                 <p>Your browser does not support iframes.</p>
             </iframe>
         {{/each}}

--- a/src/templates/partials/pipe.hbs
+++ b/src/templates/partials/pipe.hbs
@@ -92,7 +92,7 @@
     {{#isTabEnabled navTabs "example"}}
     <div class="tab-pane fade {{#isInitialTab navTabs "example"}}active in{{/isInitialTab}}" id="c-example">
         {{#each pipe.exampleUrls}}
-            <iframe src="{{this}}" style="height: 100vh; width: 100%;">
+            <iframe class="exampleContainer" src="{{this}}">
                 <p>Your browser does not support iframes.</p>
             </iframe>
         {{/each}}

--- a/test/src/cli/cli-generation-big-app.spec.ts
+++ b/test/src/cli/cli-generation-big-app.spec.ts
@@ -237,7 +237,7 @@ describe('CLI simple generation - big app', () => {
     it('should have an example tab', () => {
         const file = read(distFolder + '/components/TodoComponent.html');
         expect(file).to.contain('data-link="example">Examples</a');
-        expect(file).to.contain('iframe src=');
+        expect(file).to.contain('iframe class="exampleContainer"');
     });
 
     it('should have managed array declaration in modules', () => {


### PR DESCRIPTION
@vogloblinsky, last night I realized there were additional example tabs that needed the fix for the double-scrollbar issue. I left out directive, pipe, and injectable.

This PR fixes those.