### PR TITLE
fix(app): href paths for @link in miscellaneous

### DIFF
--- a/src/templates/partials/miscellaneous-enumerations.hbs
+++ b/src/templates/partials/miscellaneous-enumerations.hbs
@@ -7,5 +7,5 @@
 
 {{#each miscellaneous.groupedEnumerations}}
     <h3>{{@key}}</h3>
-    {{> block-enum enums=this title='false'}}
+    {{> block-enum enums=this title='false' depth=../depth}}
 {{/each}}

--- a/src/templates/partials/miscellaneous-functions.hbs
+++ b/src/templates/partials/miscellaneous-functions.hbs
@@ -7,5 +7,5 @@
 
 {{#each miscellaneous.groupedFunctions}}
     <h3>{{@key}}</h3>
-    {{> block-method methods=this title=''}}
+    {{> block-method methods=this title='' depth=../depth}}
 {{/each}}

--- a/src/templates/partials/miscellaneous-typealiases.hbs
+++ b/src/templates/partials/miscellaneous-typealiases.hbs
@@ -7,5 +7,5 @@
 
 {{#each miscellaneous.groupedTypeAliases}}
     <h3>{{@key}}</h3>
-    {{> block-typealias typealias=this title='false'}}
+    {{> block-typealias typealias=this title='false' depth=../depth}}
 {{/each}}

--- a/src/templates/partials/miscellaneous-variables.hbs
+++ b/src/templates/partials/miscellaneous-variables.hbs
@@ -7,5 +7,5 @@
 
 {{#each miscellaneous.groupedVariables}}
     <h3>{{@key}}</h3>
-    {{> block-property properties=this title=''}}
+    {{> block-property properties=this title='' depth=../depth}}
 {{/each}}

--- a/test/src/cli/cli-generation-big-app.spec.ts
+++ b/test/src/cli/cli-generation-big-app.spec.ts
@@ -760,6 +760,11 @@ describe('CLI simple generation - big app', () => {
         );
     });
 
+    it('correct http reference for other classes using @link in description of a miscellaneous function', () => {
+        let file = read(distFolder + '/miscellaneous/functions.html');
+        expect(file).to.contain('<a href="../components/ListComponent.html">ListComponent</a>');
+    });
+
     it('shorten long arrow function declaration for properties', () => {
         let file = read(distFolder + '/classes/Todo.html');
         expect(file).to.contain('() &#x3D;&gt; {...}</code>');

--- a/test/src/todomvc-ng2/src/app/shared/miscellaneous/miscellaneous.ts
+++ b/test/src/todomvc-ng2/src/app/shared/miscellaneous/miscellaneous.ts
@@ -7,7 +7,7 @@ export const PI: number = 3.14;
 export let PIT = 4;
 
 /**
- * A foo bar function
+ * A foo bar function. Test link for other class {@link ListComponent}
  *
  * @param {string} status A status
  */


### PR DESCRIPTION
Currently there is subtle error in templates that causes @link from miscellaneous to have missing '../' from href paths. Please see https://stomp-js.github.io/api-docs/latest/miscellaneous/functions.html (notice link to `RxStompService`.

This commit is for your review. I will make changes as per your suggestions.

Currently I have added test case for only functions, if you find the approach alright, I will add test cases for enumerations, types, and variables.