### PR TITLE
fix(Engine): Code blocks in Markdown not work as expected

### DIFF
--- a/src/app/engines/markdown.engine.ts
+++ b/src/app/engines/markdown.engine.ts
@@ -49,6 +49,7 @@ export class MarkdownEngine {
 
         this.markedInstance.setOptions({
             renderer: renderer,
+            gfm: true,
             breaks: false
         });
     }


### PR DESCRIPTION
Hi,

The #750 problem was due to the inclusion of the Markdown engine to PDF in the commit 1d9b49f30b6df9ffc30b43ad4657d53e51ea84e0

In this engine it is established that the Marked instance (shared between this engine and Markdown to render the HTML pages) does not use the Github Flavored Markdown on which the code blocks depend. I have enabled the GFM in the Markdown engine, which makes the code blocks work correctly again. I haven't touched the PDF engine to enable it in this one since I observe that it is currently in development and I don't know what is the expected behavior for this part.

Greetings.