### PR TITLE
Update postinstall so that it doesn't cause failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "presaucelabs-test-e2e-mocha": "npm run test:simple-doc",
         "saucelabs-test-e2e-mocha": "cross-env MODE_LOCAL=0 npm run test-e2e-mocha",
         "local-test-e2e-mocha": "cross-env MODE_LOCAL=1 npm run test-e2e-mocha",
-        "postinstall": "opencollective postinstall",
+        "postinstall": "opencollective postinstall || exit 0",
         "format:check": "prettier --config ./.prettierrc --list-different \"src/**/*.ts\"",
         "format:write": "prettier --config ./.prettierrc --write \"src/**/*.ts\""
     },


### PR DESCRIPTION
There are a few known scenarios where the opencollective postinstall npm script can cause things to break further down the pipeline - a few being 'certain build/CI environments', 'script permission issues' and 'offline installs'.... 

Arguably, displaying a banner soliciting funding shouldn't disrupt the development or build processes of projects leveraging libraries that are optionally, and non-functionally, using opencollective.

Ultimately, at the heart of the failure, is a non 0 exit code being returned in the cases that opencollective fails to properly execute. 

To prevent this non-zero exit code failure so that subsequent npm processes aren't disrupted as a result of non-functional dependency issues, a "|| exit 0" should be added to the postinstall npm script.

There are many discussions about this issue and workaround - here are a few:
https://github.com/opencollective/opencollective-cli/issues/5
https://github.com/nuxt/nuxt.js/issues/1357
https://github.com/opencollective/opencollective-cli/issues/3
https://github.com/OpenCollective/opencollective-postinstall/issues/2