### PR TITLE
Avoid pathological out of memory on large datasets

### DIFF
--- a/src/app/application.ts
+++ b/src/app/application.ts
@@ -2359,10 +2359,8 @@ at least one config for the 'info' or 'source' tab in --navTabConfig.`);
             });
         }
 
-        return FileEngine.write(finalPath, htmlData).catch(err => {
-            logger.error('Error during ' + page.name + ' page generation');
-            return Promise.reject('');
-        });
+        FileEngine.writeSync(finalPath, htmlData);
+        return Promise.resolve();
     }
 
     public processPages() {
@@ -2572,12 +2570,12 @@ at least one config for the 'info' or 'source' tab in --navTabConfig.`);
                         if (Configuration.mainData.customLogo !== '') {
                             logger.info(`Custom logo supplied`);
                             fs.copy(
+                                path.resolve(cwd + path.sep + Configuration.mainData.customLogo),
                                 path.resolve(
-                                    cwd +
-                                    path.sep +
-                                    Configuration.mainData.customLogo
+                                    finalOutput +
+                                        '/images/' +
+                                        Configuration.mainData.customLogo.split('/').pop()
                                 ),
-                                path.resolve(finalOutput + '/images/' + Configuration.mainData.customLogo.split("/").pop()),
                                 errorCopyLogo => {
                                     // tslint:disable-line
                                     if (errorCopyLogo) {

--- a/src/app/engines/file.engine.ts
+++ b/src/app/engines/file.engine.ts
@@ -35,6 +35,10 @@ export class FileEngine {
         });
     }
 
+    public writeSync(filepath: string, contents: string): void {
+        fs.outputFileSync(filepath, contents);
+    }
+
     public getSync(filepath: string): string {
         return fs.readFileSync(path.resolve(filepath), 'utf8');
     }


### PR DESCRIPTION
Do not asynchronously queue writes of the output files when all the
renders are happening on the same the same tick. On large datasets,
this causes the output to stay in memory until all the renders are done.

In a pathologic case we observed heap usage grow to 22GB (!).

Another different way to fix this would be wrap the `HtmlEngine.render` operation in an async hop (e.g. via a Promise). However, I prefer the solution in this PR as it keeps the lifetime of the rendered data is as small as possible – no need to keep it alive across turns of the even loop.

The pathological example where we observed was in https://github.com/googleapis/google-api-nodejs-client. Reproducing the issues should be as simple as cloning the repo; `npm i` and then `node --max-old-space-size=23000 node_modules/@compodoc/compodoc/bin/index-cli.js src/apis/compute -d ./docs/compute --disableSearch`.

If the problem isn't obvious, this small 'repro' should illustrate it: https://gist.github.com/ofrobots/c105c2edd4873bdd88ac0846e277245f

Thanks for all your work on this library, btw!

/cc @JustinBeckwith 