### PR TITLE
fix(compiler): Display Injectable example as TypeScript

### DIFF
--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -399,7 +399,10 @@ export class AngularDependencies extends FrameworkDependencies {
                                 id: 'injectable-' + name + '-' + hash,
                                 file: file,
                                 properties: IO.properties,
-                                methods: IO.methods,
+                                methods: IO.methods.map(method => ({
+                                    ...method,
+                                    type: 'typescript'
+                                })),
                                 description: IO.description,
                                 sourceCode: srcFile.getText(),
                                 exampleUrls: this.componentHelper.getComponentExampleUrls(

--- a/src/app/engines/html-engine-helpers/jsdoc-code-example.helper.ts
+++ b/src/app/engines/html-engine-helpers/jsdoc-code-example.helper.ts
@@ -36,7 +36,7 @@ export class JsdocCodeExampleHelper implements IHtmlEngineHelper {
         let type = 'html';
 
         if (options.hash.type) {
-            type = options.hash.type;
+            type = options.hash.type || context.type;
         }
 
         for (i; i < len; i++) {
@@ -49,10 +49,11 @@ export class JsdocCodeExampleHelper implements IHtmlEngineHelper {
                                 .replace(/<caption>/g, '<b><i>')
                                 .replace(/\/caption>/g, '/b></i>');
                         } else {
-                            tag.comment =
-                                `<pre class="line-numbers"><code class="language-${type}">` +
-                                this.getHtmlEntities(this.cleanTag(jsdocTags[i].comment)) +
-                                `</code></pre>`;
+                            const comment =
+                                type === 'html'
+                                    ? this.getHtmlEntities(this.cleanTag(jsdocTags[i].comment))
+                                    : jsdocTags[i].comment;
+                            tag.comment = `<pre class="line-numbers"><code class="language-${type}">${comment}</code></pre>`;
                         }
                         tags.push(tag);
                     }

--- a/src/templates/partials/block-method.hbs
+++ b/src/templates/partials/block-method.hbs
@@ -166,7 +166,7 @@
                     </div>
                     {{/jsdoc-params-valid}}
                     <div>
-                        {{#jsdoc-code-example jsdoctags}}
+                        {{#jsdoc-code-example jsdoctags type=type}}
                         <b>{{t "example" }} :</b>
                         {{#each tags}}
                         <div>


### PR DESCRIPTION
Fixes #684 

This *hacky* fix changes the code block language of `@example` TSDocs to TypeScript instead of HTML when coming from an Injectable.
```ts
@Injectable()
class DnsHealthIndicator {
  /**
  * @example
   * dnsHealthIndicator.pingCheck('google', 'https://google.com', { timeout: 800 })
   */
  pingCheck(...);
}
```
would generate:

![Selection_035](https://user-images.githubusercontent.com/9899423/56866107-ed32f100-69d5-11e9-86fb-daddaa666403.png)
