### PR TITLE
max-search-results-811

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,12 @@ See this folder for more details : [DOCS](./docs/README.md)
 ### Development process
 
 - open one terminal and run inside compodoc folder : `npm run start`
-- open another terminal with the source code of the [demo project](https://github.com/compodoc/compodoc-demo-todomvc-angular), and run `node ../compodoc/bin/index-cli.js -p src/tsconfig.json -a screenshots -n 'TodoMVC Angular documentation' --includes additional-doc --toggleMenuItems "'all'" -s`
+- open another terminal with the source code of the [demo project](https://github.com/compodoc/compodoc-demo-todomvc-angular), and run `node ../compodoc/bin/index-cli.js -p tsconfig.json -a screenshots -n 'TodoMVC Angular documentation' --includes additional-doc --toggleMenuItems "'all'" -s`
 
 ### Debugging process
 
 - open one terminal and run inside compodoc folder : `npm run start`
-- open another terminal with the source code of the [demo project](https://github.com/compodoc/compodoc-demo-todomvc-angular), and run `node --inspect ../compodoc/bin/index-cli.js -p src/tsconfig.json -a screenshots -n 'TodoMVC Angular documentation' --includes additional-doc --toggleMenuItems "'all'" -s`
+- open another terminal with the source code of the [demo project](https://github.com/compodoc/compodoc-demo-todomvc-angular), and run `node --inspect ../compodoc/bin/index-cli.js -p tsconfig.json -a screenshots -n 'TodoMVC Angular documentation' --includes additional-doc --toggleMenuItems "'all'" -s`
 
 ## <a name="issue"></a> Found an Issue?
 If you find a bug in the source code or a mistake in the documentation, you can help us by [submitting an issue](#submit-issue) to our [GitHub Repository][github]. Even better, you can  [submit a Pull Request](#submit-pr) with a fix.

--- a/src-refactored/core/entities/public-configuration.ts
+++ b/src-refactored/core/entities/public-configuration.ts
@@ -42,6 +42,7 @@ export class PublicConfiguration {
     public tsconfig: string;
     public unitTestCoverage: string;
     public watch: boolean;
+    public maxSearchResults: string;
 
     constructor() {}
 }

--- a/src-refactored/core/entities/public-flags.ts
+++ b/src-refactored/core/entities/public-flags.ts
@@ -270,5 +270,11 @@ export const PUBLIC_FLAGS: Flag[] = [
         flag: '-w, --watch',
         description: 'Watch source files after serve and force documentation rebuild',
         defaultValue: false
+    },
+    {
+        label: 'maxSearchResults',
+        flag: '--maxSearchResults [number]',
+        description: 'Max search results on the results page. To show all results, set to 0',
+        defaultValue: 15
     }
 ];

--- a/src/app/configuration.ts
+++ b/src/app/configuration.ts
@@ -86,7 +86,8 @@ export class Configuration implements ConfigurationInterface {
         gaSite: '',
         angularProject: false,
         angularJSProject: false,
-        language: COMPODOC_DEFAULTS.language
+        language: COMPODOC_DEFAULTS.language,
+        maxSearchResults: 15
     };
 
     private static instance: Configuration;

--- a/src/app/interfaces/main-data.interface.ts
+++ b/src/app/interfaces/main-data.interface.ts
@@ -78,4 +78,5 @@ export interface MainDataInterface {
     angularProject: boolean;
     angularJSProject: boolean;
     language: string;
+    maxSearchResults: number;
 }

--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -177,6 +177,11 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
             .option('--customLogo [path]', 'Use a custom logo')
             .option('--gaID [id]', 'Google Analytics tracking ID')
             .option('--gaSite [site]', 'Google Analytics site name', COMPODOC_DEFAULTS.gaSite)
+            .option(
+                '--maxSearchResults [maxSearchResults]',
+                'Max search results on the results page. To show all results, set to 0',
+                COMPODOC_DEFAULTS.maxSearchResults
+            )
             .parse(process.argv);
 
         let outputHelp = () => {
@@ -595,6 +600,10 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
         }
         if (program.tsconfig) {
             Configuration.mainData.tsconfig = program.tsconfig;
+        }
+
+        if (program.maxSearchResults) {
+            Configuration.mainData.maxSearchResults = program.maxSearchResults;
         }
 
         if (configFile.files) {

--- a/src/resources/js/search/search-lunr.js
+++ b/src/resources/js/search/search-lunr.js
@@ -36,7 +36,7 @@
 
         d.done({
             query: q,
-            results: results.slice(0, length),
+            results: length === 0 ? results : results.slice(0, length),
             count: results.length
         });
 

--- a/src/resources/js/search/search.js
+++ b/src/resources/js/search/search.js
@@ -1,8 +1,5 @@
 (function(compodoc) {
-    var MAX_RESULTS = 15,
-        MAX_DESCRIPTION_SIZE = 500,
-
-        usePushState = (typeof history.pushState !== 'undefined'),
+    var usePushState = (typeof history.pushState !== 'undefined'),
 
     // DOM Elements
         $body = $('body'),
@@ -120,7 +117,7 @@
             $mainContainer.css('margin-top', '100px');
         }
 
-        throttle(compodoc.search.query(q, 0, MAX_RESULTS)
+        throttle(compodoc.search.query(q, 0, MAX_SEARCH_RESULTS)
         .then(function(results) {
             displayResults(results);
         }), 1000);

--- a/src/templates/page.hbs
+++ b/src/templates/page.hbs
@@ -154,6 +154,9 @@
             {{else}}
             var COMPODOC_CURRENT_PAGE_URL = '{{data.name}}.html';
             {{/if}}
+            {{#unless data.disableSearch}}
+            var MAX_SEARCH_RESULTS = {{data.maxSearchResults}};
+            {{/unless}}
        </script>
 
        <script src="{{relativeURL data.depth }}js/libs/custom-elements.min.js"></script>

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -33,5 +33,6 @@ export const COMPODOC_DEFAULTS = {
     },
     gaSite: 'auto',
     coverageTestShowOnlyFailed: false,
-    language: 'en-US'
+    language: 'en-US',
+    maxSearchResults: 15
 };

--- a/test/fixtures/test-templates/page.hbs
+++ b/test/fixtures/test-templates/page.hbs
@@ -149,6 +149,9 @@
             {{else}}
             var COMPODOC_CURRENT_PAGE_URL = '{{data.name}}.html';
             {{/if}}
+            {{#unless data.disableSearch}}
+            var MAX_SEARCH_RESULTS = {{data.maxSearchResults}};
+            {{/unless}}
        </script>
 
        <script src="{{relativeURL data.depth }}js/libs/custom-elements.min.js"></script>

--- a/test/src/cli/cli-max-search-results.spec.ts
+++ b/test/src/cli/cli-max-search-results.spec.ts
@@ -1,0 +1,62 @@
+import * as chai from 'chai';
+import { temporaryDir, shell, pkg, exists, exec, read, shellAsync } from '../helpers';
+const expect = chai.expect,
+    tmp = temporaryDir();
+
+describe('CLI max search results', () => {
+    const distFolder = tmp.name + '-maxSearchResults';
+
+    describe('custom maxSearchResults', () => {
+        let coverageFile;
+        before(function(done) {
+            tmp.create(distFolder);
+            let ls = shell('node', [
+                './bin/index-cli.js',
+                '-p',
+                './test/fixtures/sample-files/tsconfig.simple.json',
+                '-d',
+                distFolder,
+                '--maxSearchResults',
+                '20'
+            ]);
+
+            if (ls.stderr.toString() !== '') {
+                console.error(`shell error: ${ls.stderr.toString()}`);
+                done('error');
+            }
+            coverageFile = read(`${distFolder}/index.html`);
+            done();
+        });
+        after(() => tmp.clean(distFolder));
+
+        it('it should have a MAX_SEARCH_RESULT of 20', () => {
+            expect(coverageFile).to.contain('var MAX_SEARCH_RESULTS = 20;');
+        });
+    });
+
+    describe('default maxSearchResult', () => {
+        let coverageFile;
+        before(function(done) {
+            tmp.create(distFolder);
+            let ls = shell('node', [
+                './bin/index-cli.js',
+                '-p',
+                './test/fixtures/sample-files/tsconfig.simple.json',
+                '-d',
+                distFolder
+            ]);
+
+            if (ls.stderr.toString() !== '') {
+                console.error(`shell error: ${ls.stderr.toString()}`);
+                done('error');
+            }
+            coverageFile = read(`${distFolder}/index.html`);
+            done();
+        });
+        after(() => tmp.clean(distFolder));
+
+        it('it should have a MAX_SEARCH_RESULT of 15', () => {
+            expect(coverageFile).to.contain('var MAX_SEARCH_RESULTS = 15;');
+        });
+    });
+});


### PR DESCRIPTION
Fixing issue #811  for adding a max search results to the options.

This was tested for the options 0, numerous numbers and with the default for the compodoc-demo-todomvc-angular project.

I also included a small fix for the contributing documentation.