### PR TITLE
fix(app): support new lazy loading syntax in Angular 8

### DIFF
--- a/src/utils/router-parser.util.ts
+++ b/src/utils/router-parser.util.ts
@@ -22,6 +22,7 @@ export class RouterParserUtil {
     private rootModule: string;
     private cleanModulesTree;
     private modulesWithRoutes = [];
+    private transformAngular8ImportSyntax = /(['"]loadChildren['"]:)\(\)=>"import\((\\'|'|")([^'"]+?)(\\'|'|")\)\.then\(\w+?=>\S+?\.([^)]+?)\)(\\'|'|")/g;
 
     private static instance: RouterParserUtil;
     private constructor() {}
@@ -65,6 +66,12 @@ export class RouterParserUtil {
         if (testTrailingComma !== -1) {
             routesWithoutSpaces = routesWithoutSpaces.replace('},]', '}]');
         }
+
+        routesWithoutSpaces = routesWithoutSpaces.replace(
+            this.transformAngular8ImportSyntax,
+            '$1"$3#$5"'
+        );
+
         return JSON5.parse(routesWithoutSpaces);
     }
 
@@ -74,6 +81,12 @@ export class RouterParserUtil {
         if (testTrailingComma !== -1) {
             routesWithoutSpaces = routesWithoutSpaces.replace('},]', '}]');
         }
+
+        routesWithoutSpaces = routesWithoutSpaces.replace(
+            this.transformAngular8ImportSyntax,
+            '$1"$3#$5"'
+        );
+
         return routesWithoutSpaces;
     }
 

--- a/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about-routing.module.ts
+++ b/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about-routing.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { AboutComponent } from './about.component';
+
+const ABOUT_ROUTES: Routes = [{ path: '', component: AboutComponent }];
+
+@NgModule({
+    imports: [RouterModule.forChild(ABOUT_ROUTES)],
+    exports: [RouterModule]
+})
+export class AboutRoutingModule {}

--- a/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about.component.html
+++ b/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about.component.html
@@ -1,0 +1,5 @@
+<div class="todoapp">
+    <header class="header"></header>
+    <list class="main"></list>
+    <footer></footer>
+</div>

--- a/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about.component.ts
+++ b/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+/**
+ * The about component
+ */
+@Component({
+    selector: 'about',
+    template: `
+        <div class="todoapp">
+            <header class="header"></header>
+            <list class="main"></list>
+            <footer></footer>
+        </div>
+    `
+})
+export class AboutComponent {}

--- a/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about.module.ts
+++ b/test/fixtures/todomvc-ng2-simple-routing/src/app/about/about.module.ts
@@ -1,0 +1,32 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
+
+import { AboutComponent } from './about.component';
+import { AboutRoutingModule } from './about-routing.module';
+
+import { HeaderModule } from '../header/';
+import { ListModule } from '../list/';
+import { FooterModule } from '../footer/';
+
+/**
+ * The header module
+ *
+ * Just embedding <about> component and it's routing definition in {@link AboutRoutingModule}
+ */
+@NgModule({
+    declarations: [AboutComponent],
+    imports: [
+        BrowserModule,
+        FormsModule,
+        HttpModule,
+
+        HeaderModule.forRoot(),
+        ListModule,
+        FooterModule,
+        AboutRoutingModule
+    ],
+    exports: [AboutComponent]
+})
+export class AboutModule {}

--- a/test/fixtures/todomvc-ng2-simple-routing/src/app/about/index.ts
+++ b/test/fixtures/todomvc-ng2-simple-routing/src/app/about/index.ts
@@ -1,0 +1,2 @@
+export * from './about.module';
+export * from './about.component';

--- a/test/fixtures/todomvc-ng2-simple-routing/src/app/app-routing.module.ts
+++ b/test/fixtures/todomvc-ng2-simple-routing/src/app/app-routing.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 export const APP_ROUTES: Routes = [
-    { path: 'about', loadChildren: './about/about.module#AboutModule' },
+    { path: 'about', loadChildren: () => import('./about/about.module').then(m => m.AboutModule) },
     { path: '', redirectTo: 'home', pathMatch: 'full' },
     { path: '**', redirectTo: 'home', pathMatch: 'full' }
 ];

--- a/test/src/cli/cli-routes-graph.spec.ts
+++ b/test/src/cli/cli-routes-graph.spec.ts
@@ -84,6 +84,33 @@ describe('CLI Routes graph', () => {
         });
     });
 
+    describe('should support lazy loading modules with new loadChildren syntax', () => {
+        before(function(done) {
+            tmp.create(distFolder);
+            let ls = shell('node', [
+                './bin/index-cli.js',
+                '-p',
+                './test/fixtures/todomvc-ng2-simple-routing/src/tsconfig.json',
+                '-d',
+                distFolder
+            ]);
+
+            if (ls.stderr.toString() !== '') {
+                console.error(`shell error: ${ls.stderr.toString()}`);
+                done('error');
+            }
+            done();
+        });
+        after(() => tmp.clean(distFolder));
+
+        it("should have a clean graph", () => {
+            const isFileExists = exists(`${distFolder}/js/routes/routes_index.js`);
+            expect(isFileExists).to.be.true;
+            let file = read(`${distFolder}/js/routes/routes_index.js`);
+            expect(file).to.contain('AboutComponent');
+        });
+    });
+
     describe('should support if statement for bootstrapModule', () => {
         before(function(done) {
             tmp.create(distFolder);


### PR DESCRIPTION
This commit adds support for the new loadChildren lazy loading syntax introduced in Angular 8 by using a regular expression to transform the content to the old syntax prior to building the route tree.