### PR TITLE
test: fix unit tests failing on Windows

### DIFF
--- a/test/src/cli/cli-additional.spec.ts
+++ b/test/src/cli/cli-additional.spec.ts
@@ -1,3 +1,4 @@
+const eol = require('os').EOL;
 import * as chai from 'chai';
 import { temporaryDir, shell, pkg, exists, exec, read, shellAsync } from '../helpers';
 
@@ -81,7 +82,7 @@ describe('CLI Additional documentation', () => {
 
     it('should have links in correct order', () => {
         expect(fooMenuFile).to.contain(
-            `<li class="link for-chapter3">\n                                                <a href="additional-documentation/edition/edition-of-a-todo/edit-level3.html" data-type="entity-link" data-context="sub-entity" data-context-id="additional">edit-level3</a>\n                                            </li>\n                                            <li class="link for-chapter4">\n                                                <a href="additional-documentation/edition/edition-of-a-todo/edit-level3/edit-level4.html" data-type="entity-link" data-context="sub-entity" data-context-id="additional">edit-level4</a>`
+            `<li class="link for-chapter3">${eol}                                                <a href="additional-documentation/edition/edition-of-a-todo/edit-level3.html" data-type="entity-link" data-context="sub-entity" data-context-id="additional">edit-level3</a>${eol}                                            </li>${eol}                                            <li class="link for-chapter4">${eol}                                                <a href="additional-documentation/edition/edition-of-a-todo/edit-level3/edit-level4.html" data-type="entity-link" data-context="sub-entity" data-context-id="additional">edit-level4</a>`
         );
     });
 });

--- a/test/src/cli/cli-duplicates.spec.ts
+++ b/test/src/cli/cli-duplicates.spec.ts
@@ -1,3 +1,4 @@
+const eol = require('os').EOL;
 import * as chai from 'chai';
 import { temporaryDir, shell, pkg, exists, exec, read, shellAsync } from '../helpers';
 
@@ -102,7 +103,7 @@ describe('CLI duplicates support', () => {
             'components-links-module-ValidationDemoModule'
         );
         expect(file).to.contain(
-            `id="xs-components-links-module-ValidationDemoModule"\' }>\n                                            <li class="link">\n                                                <a href="components/ValidationDemo.html"\n                                                    data-type="entity-link" data-context="sub-entity" data-context-id="modules">ValidationDemo</a>`
+            `id="xs-components-links-module-ValidationDemoModule"\' }>${eol}                                            <li class="link">${eol}                                                <a href="components/ValidationDemo.html"${eol}                                                    data-type="entity-link" data-context="sub-entity" data-context-id="modules">ValidationDemo</a>`
         );
     });
 
@@ -114,10 +115,10 @@ describe('CLI duplicates support', () => {
         );
         // tslint:disable-next-line:max-line-length
         expect(file).to.contain(
-            `id="xs-components-links-module-FooterModule"\' }>\n                                            <li class="link">\n                                                <a href="components/FooterComponent-1.html"\n                                                    data-type="entity-link" data-context="sub-entity" data-context-id="modules">FooterComponent</a>`
+            `id="xs-components-links-module-FooterModule"\' }>${eol}                                            <li class="link">${eol}                                                <a href="components/FooterComponent-1.html"${eol}                                                    data-type="entity-link" data-context="sub-entity" data-context-id="modules">FooterComponent</a>`
         );
         expect(file).to.contain(
-            `<li class="link">\n                                <a href="components/FooterComponent.html" data-type="entity-link">FooterComponent</a>`
+            `<li class="link">${eol}                                <a href="components/FooterComponent.html" data-type="entity-link">FooterComponent</a>`
         );
     });
 

--- a/test/src/cli/cli-generation-big-app.spec.ts
+++ b/test/src/cli/cli-generation-big-app.spec.ts
@@ -1,3 +1,4 @@
+const eol = require('os').EOL;
 import * as chai from 'chai';
 import { temporaryDir, shell, pkg, exists, exec, read, shellAsync } from '../helpers';
 
@@ -470,21 +471,21 @@ describe('CLI simple generation - big app', () => {
     it('should have parsed correctly private, public, and static methods or properties', () => {
         expect(aboutComponentFile).to.contain('<code>privateStaticMethod()');
         expect(aboutComponentFile).to.contain(
-            `<span class="modifier">Private</span>\n                                    <span class="modifier">Static</span>`
+            `<span class="modifier">Private</span>${eol}                                    <span class="modifier">Static</span>`
         );
         expect(aboutComponentFile).to.contain('<code>protectedStaticMethod()');
         expect(aboutComponentFile).to.contain(
-            `<span class="modifier">Protected</span>\n                                    <span class="modifier">Static</span>`
+            `<span class="modifier">Protected</span>${eol}                                    <span class="modifier">Static</span>`
         );
         expect(aboutComponentFile).to.contain('<code>publicMethod()');
         expect(aboutComponentFile).to.contain('<code>publicStaticMethod()');
         expect(aboutComponentFile).to.contain('<code>staticMethod()');
         expect(aboutComponentFile).to.contain('staticReadonlyVariable');
         expect(aboutComponentFile).to.contain(
-            `<span class="modifier">Static</span>\n                                    <span class="modifier">Readonly</span>`
+            `<span class="modifier">Static</span>${eol}                                    <span class="modifier">Readonly</span>`
         );
         expect(aboutComponentFile).to.contain(
-            `<span class="modifier">Public</span>\n                                    <span class="modifier">Async</span>`
+            `<span class="modifier">Public</span>${eol}                                    <span class="modifier">Async</span>`
         );
     });
 
@@ -669,7 +670,7 @@ describe('CLI simple generation - big app', () => {
     it('should display list of import/exports/declarations/providers in asc order', () => {
         let file = read(distFolder + '/modules/AboutRoutingModule.html');
         expect(file).to.contain(
-            `<li class="list-group-item">\n                            <a href="../components/CompodocComponent.html">CompodocComponent</a>\n                        </li>\n                        <li class="list-group-item">\n                            <a href="../components/TodoMVCComponent.html">`
+            `<li class="list-group-item">${eol}                            <a href="../components/CompodocComponent.html">CompodocComponent</a>${eol}                        </li>${eol}                        <li class="list-group-item">${eol}                            <a href="../components/TodoMVCComponent.html">`
         );
     });
 
@@ -686,7 +687,7 @@ describe('CLI simple generation - big app', () => {
 
     it('should support Type parameters', () => {
         expect(appComponentFile).to.contain(
-            `<ul class="type-parameters">\n                        <li>T</li>\n                        <li>K</li>\n                    </ul>`
+            `<ul class="type-parameters">${eol}                        <li>T</li>${eol}                        <li>K</li>${eol}                    </ul>`
         );
     });
 

--- a/test/src/cli/cli-uniqid.spec.ts
+++ b/test/src/cli/cli-uniqid.spec.ts
@@ -28,6 +28,11 @@ describe('CLI Uniq id for file', () => {
     after(() => tmp.clean(distFolder));
 
     it('it should contain a uniqid', () => {
-        expect(indexFile).to.contain('e359b2a2e33e7b411a7b7e52efea7ba0');
+        const expectedHash =
+            process.platform === 'win32'
+                ? '275074cbab50c18beecd656b624c9356'
+                : 'e359b2a2e33e7b411a7b7e52efea7ba0';
+
+        expect(indexFile).to.contain(expectedHash);
     });
 });


### PR DESCRIPTION
Change tests evaluating HTML output to use EOL constant from OS
module instead of hardcoded \n. Also update uniqid spec to account
for different MD5s on Windows due to the difference path separator.