### PR TITLE
fix(app): fix path separator replace on Windows during route processing

### DIFF
--- a/src/utils/router-parser.util.ts
+++ b/src/utils/router-parser.util.ts
@@ -154,14 +154,11 @@ export class RouterParserUtil {
                                                 argument.text,
                                                 this.modulesWithRoutes[i].filename
                                             );
-                                            let cleaner = (process.cwd() + path.sep).replace(
-                                                /\\/g,
-                                                '/'
-                                            );
-                                            argumentImportPath = argumentImportPath.replace(
-                                                cleaner,
-                                                ''
-                                            );
+
+                                            argumentImportPath = argumentImportPath
+                                                .replace(process.cwd() + path.sep, '')
+                                                .replace(/\\/g, '/');
+
                                             if (
                                                 argument.text &&
                                                 route.name === argument.text &&


### PR DESCRIPTION
Remove the CWD from the import path before replacing backslashes with
forward slashes. Converting the slashes first causes the CWD replace to
fail on Windows.