### PR TITLE
Removed if statement so 'exclude' and 'include' are included if they …

### DIFF
--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -693,85 +693,70 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                     logger.info('Using tsconfig file ', _file);
 
                     let tsConfigFile = readConfig(_file);
-                    scannedFiles = tsConfigFile.files;
-                    if (scannedFiles) {
-                        scannedFiles = handlePath(scannedFiles, cwd);
+                    if (tsConfigFile.files) {
+                        scannedFiles = handlePath(tsConfigFile.files, cwd);
                     }
 
-                    if (typeof scannedFiles === 'undefined') {
-                        excludeFiles = tsConfigFile.exclude || [];
-                        includeFiles = tsConfigFile.include || [];
-                        scannedFiles = [];
+                    excludeFiles = tsConfigFile.exclude || [];
+                    includeFiles = tsConfigFile.include || [];
 
-                        let excludeParser = new ParserUtil(),
-                            includeParser = new ParserUtil();
+                    let excludeParser = new ParserUtil(),
+                        includeParser = new ParserUtil();
 
-                        excludeParser.init(excludeFiles, cwd);
-                        includeParser.init(includeFiles, cwd);
+                    excludeParser.init(excludeFiles, cwd);
+                    includeParser.init(includeFiles, cwd);
 
-                        let startCwd = cwd;
+                    let startCwd = cwd;
 
-                        let excludeParserTestFilesWithCwdDepth = excludeParser.testFilesWithCwdDepth();
-                        if (!excludeParserTestFilesWithCwdDepth.status) {
-                            startCwd = excludeParser.updateCwd(
-                                cwd,
-                                excludeParserTestFilesWithCwdDepth.level
-                            );
+                    let excludeParserTestFilesWithCwdDepth = excludeParser.testFilesWithCwdDepth();
+                    if (!excludeParserTestFilesWithCwdDepth.status) {
+                        startCwd = excludeParser.updateCwd(
+                            cwd,
+                            excludeParserTestFilesWithCwdDepth.level
+                        );
+                    }
+                    let includeParserTestFilesWithCwdDepth = includeParser.testFilesWithCwdDepth();
+                    if (!includeParser.testFilesWithCwdDepth().status) {
+                        startCwd = includeParser.updateCwd(
+                            cwd,
+                            includeParserTestFilesWithCwdDepth.level
+                        );
+                    }
+
+                    let finder = require('findit2')(startCwd || '.');
+
+                    finder.on('directory', function(dir, stat, stop) {
+                        let base = path.basename(dir);
+                        if (base === '.git' || base === 'node_modules') {
+                            stop();
                         }
-                        let includeParserTestFilesWithCwdDepth = includeParser.testFilesWithCwdDepth();
-                        if (!includeParser.testFilesWithCwdDepth().status) {
-                            startCwd = includeParser.updateCwd(
-                                cwd,
-                                includeParserTestFilesWithCwdDepth.level
-                            );
-                        }
+                    });
 
-                        let finder = require('findit2')(startCwd || '.');
-
-                        finder.on('directory', function(dir, stat, stop) {
-                            let base = path.basename(dir);
-                            if (base === '.git' || base === 'node_modules') {
-                                stop();
-                            }
-                        });
-
-                        finder.on('file', (file, stat) => {
-                            if (/(spec|\.d)\.ts/.test(file)) {
-                                logger.warn('Ignoring', file);
-                            } else if (
-                                excludeParser.testFile(file) &&
-                                path.extname(file) === '.ts'
-                            ) {
-                                logger.warn('Excluding', file);
-                            } else if (includeFiles.length > 0) {
-                                /**
-                                 * If include provided in tsconfig, use only this source,
-                                 * and not files found with global findit scan in working directory
-                                 */
-                                if (path.extname(file) === '.ts' && includeParser.testFile(file)) {
-                                    logger.debug('Including', file);
-                                    scannedFiles.push(file);
-                                } else {
-                                    if (path.extname(file) === '.ts') {
-                                        logger.warn('Excluding', file);
-                                    }
-                                }
-                            } else {
+                    finder.on('file', (file, stat) => {
+                        if (/(spec|\.d)\.ts/.test(file)) {
+                            logger.warn('Ignoring', file);
+                        } else if (excludeParser.testFile(file) && path.extname(file) === '.ts') {
+                            logger.warn('Excluding', file);
+                        } else if (includeFiles.length > 0) {
+                            /**
+                             * If include provided in tsconfig, use only this source,
+                             * and not files found with global findit scan in working directory
+                             */
+                            if (path.extname(file) === '.ts' && includeParser.testFile(file)) {
                                 logger.debug('Including', file);
                                 scannedFiles.push(file);
-                            }
-                        });
-
-                        finder.on('end', () => {
-                            super.setFiles(scannedFiles);
-                            if (program.coverageTest || program.coverageTestPerFile) {
-                                logger.info('Run documentation coverage test');
-                                super.testCoverage();
                             } else {
-                                super.generate();
+                                if (path.extname(file) === '.ts') {
+                                    logger.warn('Excluding', file);
+                                }
                             }
-                        });
-                    } else {
+                        } else {
+                            logger.debug('Including', file);
+                            scannedFiles.push(file);
+                        }
+                    });
+
+                    finder.on('end', () => {
                         super.setFiles(scannedFiles);
                         if (program.coverageTest || program.coverageTestPerFile) {
                             logger.info('Run documentation coverage test');
@@ -779,7 +764,7 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                         } else {
                             super.generate();
                         }
-                    }
+                    });
                 }
             } else if (Configuration.mainData.tsconfig && program.args.length > 0) {
                 /**
@@ -820,85 +805,70 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                         logger.info('Using tsconfig file ', _file);
 
                         let tsConfigFile = readConfig(_file);
-                        scannedFiles = tsConfigFile.files;
-                        if (scannedFiles) {
-                            scannedFiles = handlePath(scannedFiles, cwd);
+                        if (tsConfigFile.files) {
+                            scannedFiles = handlePath(tsConfigFile.files, cwd);
                         }
 
-                        if (typeof scannedFiles === 'undefined') {
-                            excludeFiles = tsConfigFile.exclude || [];
-                            includeFiles = tsConfigFile.include || [];
-                            scannedFiles = [];
+                        excludeFiles = tsConfigFile.exclude || [];
+                        includeFiles = tsConfigFile.include || [];
 
-                            let excludeParser = new ParserUtil(),
-                                includeParser = new ParserUtil();
+                        let excludeParser = new ParserUtil(),
+                            includeParser = new ParserUtil();
 
-                            excludeParser.init(excludeFiles, cwd);
-                            includeParser.init(includeFiles, cwd);
+                        excludeParser.init(excludeFiles, cwd);
+                        includeParser.init(includeFiles, cwd);
 
-                            let startCwd = sourceFolder;
+                        let startCwd = sourceFolder;
 
-                            let excludeParserTestFilesWithCwdDepth = excludeParser.testFilesWithCwdDepth();
-                            if (!excludeParserTestFilesWithCwdDepth.status) {
-                                startCwd = excludeParser.updateCwd(
-                                    cwd,
-                                    excludeParserTestFilesWithCwdDepth.level
-                                );
+                        let excludeParserTestFilesWithCwdDepth = excludeParser.testFilesWithCwdDepth();
+                        if (!excludeParserTestFilesWithCwdDepth.status) {
+                            startCwd = excludeParser.updateCwd(
+                                cwd,
+                                excludeParserTestFilesWithCwdDepth.level
+                            );
+                        }
+                        let includeParserTestFilesWithCwdDepth = includeParser.testFilesWithCwdDepth();
+                        if (!includeParser.testFilesWithCwdDepth().status) {
+                            startCwd = includeParser.updateCwd(
+                                cwd,
+                                includeParserTestFilesWithCwdDepth.level
+                            );
+                        }
+
+                        let finder = require('findit2')(path.resolve(startCwd));
+
+                        finder.on('directory', function(dir, stat, stop) {
+                            let base = path.basename(dir);
+                            if (base === '.git' || base === 'node_modules') {
+                                stop();
                             }
-                            let includeParserTestFilesWithCwdDepth = includeParser.testFilesWithCwdDepth();
-                            if (!includeParser.testFilesWithCwdDepth().status) {
-                                startCwd = includeParser.updateCwd(
-                                    cwd,
-                                    includeParserTestFilesWithCwdDepth.level
-                                );
-                            }
+                        });
 
-                            let finder = require('findit2')(path.resolve(startCwd));
-
-                            finder.on('directory', function(dir, stat, stop) {
-                                let base = path.basename(dir);
-                                if (base === '.git' || base === 'node_modules') {
-                                    stop();
-                                }
-                            });
-
-                            finder.on('file', (file, stat) => {
-                                if (/(spec|\.d)\.ts/.test(file)) {
-                                    logger.warn('Ignoring', file);
-                                } else if (excludeParser.testFile(file)) {
-                                    logger.warn('Excluding', file);
-                                } else if (includeFiles.length > 0) {
-                                    /**
-                                     * If include provided in tsconfig, use only this source,
-                                     * and not files found with global findit scan in working directory
-                                     */
-                                    if (
-                                        path.extname(file) === '.ts' &&
-                                        includeParser.testFile(file)
-                                    ) {
-                                        logger.debug('Including', file);
-                                        scannedFiles.push(file);
-                                    } else {
-                                        if (path.extname(file) === '.ts') {
-                                            logger.warn('Excluding', file);
-                                        }
-                                    }
-                                } else {
+                        finder.on('file', (file, stat) => {
+                            if (/(spec|\.d)\.ts/.test(file)) {
+                                logger.warn('Ignoring', file);
+                            } else if (excludeParser.testFile(file)) {
+                                logger.warn('Excluding', file);
+                            } else if (includeFiles.length > 0) {
+                                /**
+                                 * If include provided in tsconfig, use only this source,
+                                 * and not files found with global findit scan in working directory
+                                 */
+                                if (path.extname(file) === '.ts' && includeParser.testFile(file)) {
                                     logger.debug('Including', file);
                                     scannedFiles.push(file);
-                                }
-                            });
-
-                            finder.on('end', () => {
-                                super.setFiles(scannedFiles);
-                                if (program.coverageTest || program.coverageTestPerFile) {
-                                    logger.info('Run documentation coverage test');
-                                    super.testCoverage();
                                 } else {
-                                    super.generate();
+                                    if (path.extname(file) === '.ts') {
+                                        logger.warn('Excluding', file);
+                                    }
                                 }
-                            });
-                        } else {
+                            } else {
+                                logger.debug('Including', file);
+                                scannedFiles.push(file);
+                            }
+                        });
+
+                        finder.on('end', () => {
                             super.setFiles(scannedFiles);
                             if (program.coverageTest || program.coverageTestPerFile) {
                                 logger.info('Run documentation coverage test');
@@ -906,7 +876,7 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                             } else {
                                 super.generate();
                             }
-                        }
+                        });
                     }
                 }
             } else {


### PR DESCRIPTION
…exist.

Basically checking if scannedFiles is of type "undefined" is useless since it's always set. Excluded and include paths of tsconfig should also be included if they exist EVEN if "files" is declared.

Fix for this [issue](https://github.com/compodoc/compodoc/issues/831)