### PR TITLE
update(angular-util): update findApi to reduce runtime

### DIFF
--- a/src-refactored/infrastructure/angular/angular-api.util.ts
+++ b/src-refactored/infrastructure/angular/angular-api.util.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-
 const AngularAPIs: Array<IAngularMainApi> = require('../../data/api-list.json');
 
 export interface IApiSourceResult<T> {
@@ -36,17 +34,19 @@ export class AngularApiUtil {
     }
 
     public findApi(type: string): IApiSourceResult<IAngularMainApi> {
-        let foundedApi;
-        _.forEach(AngularAPIs, mainApi => {
-            _.forEach(mainApi.items, api => {
+        let foundApi;
+        AngularAPIs.some(mainApi => {
+            return mainApi.items.some(api => {
                 if (api.title === type) {
-                    foundedApi = api;
+                    foundApi = api;
+                    return true;
                 }
             });
         });
+
         return {
             source: 'external',
-            data: foundedApi
+            data: foundApi
         };
     }
 }


### PR DESCRIPTION
Was unsure about how to handle this as nothing is wrong, there isn't a bug so I wouldn't want to clutter issues and it's in the refactored part of the repo which I can't find much talk about what the plans are outside of the todos, which as an outsider I wouldn't have any idea what the progress is/full goal. 

But anyway, I was looking around and noticed this, the function is going through the entire list of AngularApis and all their items, even after one is found. So I modified it to use some which can shortcircuit once the api is found. I also didn't see a reason to use lodash here as it's all just array that the native functions can handle so I removed that file dependency. 

The current angular-api.util also has the same setup, so if this idea is approved I could update that one as well and include it in this pr or make another. I can also add more tests, just wasn't sure what was expected as there's only one test for the file and it's passing. 

Have always loved compodoc and am looking to get more involved. 