### PR TITLE
Allow custom decorators to be anywhere in the decorator chain

### DIFF
--- a/src/app/compiler/angular/deps/helpers/class-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/class-helper.ts
@@ -515,24 +515,24 @@ export class ClassHelper {
                             methods: members.methods
                         }
                     ];
-                } else {
-                    return [
-                        {
-                            description,
-                            rawdescription: rawdescription,
-                            methods: members.methods,
-                            indexSignatures: members.indexSignatures,
-                            properties: members.properties,
-                            kind: members.kind,
-                            constructor: members.constructor,
-                            jsdoctags: jsdoctags,
-                            extends: extendsElement,
-                            implements: implementsElements,
-                            accessors: members.accessors
-                        }
-                    ];
                 }
+                // Did not find an angular decorator in first iteration, try the next
             }
+            return [
+                {
+                    description,
+                    rawdescription: rawdescription,
+                    methods: members.methods,
+                    indexSignatures: members.indexSignatures,
+                    properties: members.properties,
+                    kind: members.kind,
+                    constructor: members.constructor,
+                    jsdoctags: jsdoctags,
+                    extends: extendsElement,
+                    implements: implementsElements,
+                    accessors: members.accessors
+                }
+            ];
         } else if (description) {
             return [
                 {


### PR DESCRIPTION
Code was previously only looking at the first decorator. Fix is
to make sure we scan all decorators before giving up and returning
default class data.

Closes #868