### PR TITLE
fix(cli): tsx files not considered in include entries

### DIFF
--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -742,18 +742,24 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                     finder.on('file', (file, stat) => {
                         if (/(spec|\.d)\.ts/.test(file)) {
                             logger.warn('Ignoring', file);
-                        } else if (excludeParser.testFile(file) && path.extname(file) === '.ts') {
+                        } else if (
+                            excludeParser.testFile(file) &&
+                            (path.extname(file) === '.ts' || path.extname(file) === '.tsx')
+                        ) {
                             logger.warn('Excluding', file);
                         } else if (includeFiles.length > 0) {
                             /**
                              * If include provided in tsconfig, use only this source,
                              * and not files found with global findit scan in working directory
                              */
-                            if (path.extname(file) === '.ts' && includeParser.testFile(file)) {
+                            if (
+                                (path.extname(file) === '.ts' || path.extname(file) === '.tsx') &&
+                                includeParser.testFile(file)
+                            ) {
                                 logger.debug('Including', file);
                                 scannedFiles.push(file);
                             } else {
-                                if (path.extname(file) === '.ts') {
+                                if (path.extname(file) === '.ts' || path.extname(file) === '.tsx') {
                                     logger.warn('Excludinge', file);
                                 }
                             }


### PR DESCRIPTION
When using the include entries from tsconfig it will now not exclude tsx files anymore