### PR TITLE
fix: generating documentation on project including inacessible folders

### DIFF
--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -13,7 +13,7 @@ import AngularVersionUtil from './utils/angular-version.util';
 import { COMPODOC_DEFAULTS } from './utils/defaults';
 import { logger } from './utils/logger';
 import { ParserUtil } from './utils/parser.util.class';
-import { handlePath, readConfig } from './utils/utils';
+import { handlePath, readConfig, ignoreDirectory } from './utils/utils';
 
 import { cosmiconfigSync } from 'cosmiconfig';
 
@@ -733,8 +733,7 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                     let finder = require('findit2')(startCwd || '.');
 
                     finder.on('directory', function(dir, stat, stop) {
-                        let base = path.basename(dir);
-                        if (base === '.git' || base === 'node_modules') {
+                        if (ignoreDirectory(dir)) {
                             stop();
                         }
                     });
@@ -856,8 +855,7 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                         let finder = require('findit2')(path.resolve(startCwd));
 
                         finder.on('directory', function(dir, stat, stop) {
-                            let base = path.basename(dir);
-                            if (base === '.git' || base === 'node_modules') {
+                            if (ignoreDirectory(dir)) {
                                 stop();
                             }
                         });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -382,3 +382,20 @@ export function detectIndent(str, count): string {
 
     return indentString(stripIndent(str), count || 0);
 }
+
+const IGNORED_DIRECTORIES = ['.git', 'node_modules'];
+
+export function ignoreDirectory(dir: string): boolean {
+    let base = path.basename(dir);
+
+    if (IGNORED_DIRECTORIES.includes(base)) return true;
+
+    try {
+        fs.accessSync(dir, fs.constants.W_OK);
+    } catch (err) {
+        logger.warn('Ignoring inaccessible folder', dir);
+        return true;
+    }
+
+    return false;
+}


### PR DESCRIPTION
In our project we have .data folder, containing some folders not accessible by current user.
There is no way to exclude it from being scanned by `findit2`.

Current behaviour: documentation generation fails with EACCESS error

New behaviour: successful generation with warning
```
[19:29:23] Ignoring inaccessible folder: /home/denis/projects/jerry/.data/postgresql
```

I planned to add unit test to `utils.ts`, but it seems project have no unit tests yet, only integration and e2e suites, so I decided to not add the whole setup and just rely on current tests to pass.

Sorry for closing and reopening, wasn't intended to.