### PR TITLE
feat: add cli option for custom path to markdowns

### DIFF
--- a/src-refactored/core/entities/public-flags.ts
+++ b/src-refactored/core/entities/public-flags.ts
@@ -284,5 +284,11 @@ export const PUBLIC_FLAGS: Flag[] = [
         flag: '--maxSearchResults [number]',
         description: 'Max search results on the results page. To show all results, set to 0',
         defaultValue: 15
+    },
+    {
+        label: 'markdownsPath',
+        flag: '--markdownsPath [path]',
+        description: 'Custom path to directory with markdown files',
+        defaultValue: ''
     }
 ];

--- a/src/app/application.ts
+++ b/src/app/application.ts
@@ -289,12 +289,17 @@ export class Application {
         );
 
         return new Promise((resolve, reject) => {
+            let filePath = '';
             let i = 0;
             let markdowns = ['readme', 'changelog', 'contributing', 'license', 'todo'];
             let numberOfMarkdowns = 5;
             let loop = () => {
                 if (i < numberOfMarkdowns) {
-                    MarkdownEngine.getTraditionalMarkdown(markdowns[i].toUpperCase()).then(
+                    filePath =
+                        Configuration.mainData.markdownsPath +
+                        path.sep +
+                        markdowns[i].toUpperCase();
+                    MarkdownEngine.getTraditionalMarkdown(filePath).then(
                         (readmeData: markdownReadedDatas) => {
                             Configuration.addPage({
                                 name: markdowns[i] === 'readme' ? 'index' : markdowns[i],

--- a/src/app/configuration.ts
+++ b/src/app/configuration.ts
@@ -31,6 +31,7 @@ export class Configuration implements ConfigurationInterface {
         license: '',
         todo: '',
         markdowns: [],
+        markdownsPath: '',
         additionalPages: [],
         pipes: [],
         classes: [],

--- a/src/app/interfaces/configuration-file.interface.ts
+++ b/src/app/interfaces/configuration-file.interface.ts
@@ -45,4 +45,5 @@ export interface ConfigurationFileInterface {
     files;
     exclude;
     include;
+    markdownsPath: string;
 }

--- a/src/app/interfaces/main-data.interface.ts
+++ b/src/app/interfaces/main-data.interface.ts
@@ -22,6 +22,7 @@ export interface MainDataInterface {
     license: string;
     todo: string;
     markdowns: any[];
+    markdownsPath: string;
     additionalPages: any;
     pipes: any;
     classes: any;

--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -395,6 +395,13 @@
             "examples": [
                 ""
             ]
+        },
+        "markdownsPath": {
+            "$id": "/properties/markdownsPath",
+            "type": "string",
+            "title": "Custom path to directory with markdown files",
+            "default": "",
+            "examples": ["markdowns/"]
         }
     }
 }

--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -183,6 +183,7 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                 'Max search results on the results page. To show all results, set to 0',
                 COMPODOC_DEFAULTS.maxSearchResults
             )
+            .option('--markdownsPath [path]', 'Custom path to directory with markdown files')
             .parse(process.argv);
 
         let outputHelp = () => {
@@ -541,6 +542,13 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
         }
         if (program.gaSite && program.gaSite !== COMPODOC_DEFAULTS.gaSite) {
             Configuration.mainData.gaSite = program.gaSite;
+        }
+
+        if (configFile.markdownsPath) {
+            Configuration.mainData.markdownsPath = configFile.markdownsPath;
+        }
+        if (program.markdownsPath) {
+            Configuration.mainData.markdownsPath = program.markdownsPath;
         }
 
         if (!this.isWatching) {

--- a/test/fixtures/todomvc-ng2/markdowns/README.md
+++ b/test/fixtures/todomvc-ng2/markdowns/README.md
@@ -1,0 +1,1 @@
+README.md file from custom directory

--- a/test/src/cli/cli-markdowns-path.spec.ts
+++ b/test/src/cli/cli-markdowns-path.spec.ts
@@ -1,0 +1,36 @@
+import * as chai from 'chai';
+import { temporaryDir, shell, read } from '../helpers';
+const expect = chai.expect,
+    tmp = temporaryDir();
+
+describe('CLI markdowns path', () => {
+    const distFolder = tmp.name + '-markdowns-path';
+    let indexFile = undefined;
+
+    describe('when specifying a custom markdown path', () => {
+        before(function(done) {
+            tmp.create(distFolder);
+            let ls = shell('node', [
+                './bin/index-cli.js',
+                '-p',
+                './test/fixtures/todomvc-ng2/src/tsconfig.json',
+                '-d',
+                distFolder,
+                '--markdownsPath',
+                './test/fixtures/todomvc-ng2/markdowns'
+            ]);
+
+            if (ls.stderr.toString() !== '') {
+                console.error(`shell error: ${ls.stderr.toString()}`);
+                done('error');
+            }
+            indexFile = read(`${distFolder}/index.html`);
+            done();
+        });
+        after(() => tmp.clean(distFolder));
+
+        it('should have content from README.md file', () => {
+            expect(indexFile).to.contain('README.md file from custom directory');
+        });
+    });
+});

--- a/test/src/cli/cli-options.spec.ts
+++ b/test/src/cli/cli-options.spec.ts
@@ -208,5 +208,12 @@ Note: Certain tabs will only be shown if applicable to a given dependency`
             expect(runHelp.stdout.toString()).to.contain('--customLogo [path]');
             expect(runHelp.stdout.toString()).to.contain('Use a custom logo');
         });
+
+        it(`--markdownsPath`, () => {
+            expect(runHelp.stdout.toString()).to.contain('--markdownsPath [path]');
+            expect(runHelp.stdout.toString()).to.contain(
+                'Custom path to directory with markdown files'
+            );
+        });
     });
 });


### PR DESCRIPTION
This PR is linked to issue #247

`--markdownsPath` option adds the ability to specify a custom location for
compodoc supported markdown files (README.md, CHANGELOG.md etc)