### PR TITLE
feat(app): add support for inferred input types

### DIFF
--- a/src/app/compiler/angular/deps/helpers/class-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/class-helper.ts
@@ -1061,6 +1061,19 @@ export class ClassHelper {
                     }
                 }
             }
+            // Try to get inferred type
+            if (property.symbol) {
+                let symbol: ts.Symbol = property.symbol;
+                if (symbol.valueDeclaration) {
+                    let symbolType = this.typeChecker.getTypeOfSymbolAtLocation(
+                        symbol,
+                        symbol.valueDeclaration
+                    );
+                    if (symbolType) {
+                        _return.type = this.typeChecker.typeToString(symbolType);
+                    }
+                }
+            }
         }
         if (property.kind === SyntaxKind.SetAccessor) {
             // For setter accessor, find type in first parameter

--- a/test/fixtures/todomvc-ng2/src/app/about/about.component.html
+++ b/test/fixtures/todomvc-ng2/src/app/about/about.component.html
@@ -1,4 +1,4 @@
 <p>
-    This application is a <a [routerLink]="['todomvc']">TodoMVC</a> example written using Angular 2, with code documented, and ready for <a [routerLink]="['compodoc']">compodoc</a>.
+    This application is a <a [routerLink]="['todomvc']">TodoMVC</a> example written using {{angularVersion}}, with code documented, and ready for <a [routerLink]="['compodoc']">compodoc</a>.
 </p>
 <router-outlet></router-outlet>

--- a/test/fixtures/todomvc-ng2/src/app/about/about.component.ts
+++ b/test/fixtures/todomvc-ng2/src/app/about/about.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, Input } from '@angular/core';
 
 import { Subscription } from 'rxjs/Subscription';
 
@@ -30,6 +30,11 @@ export class AboutComponent {
      */
     @HostListener('mouseup', ['$event.clientX', '$event.clientY'])
     onMouseup(mouseX: number, mouseY: number): void {}
+
+    /**
+     * Inherited type of Angular Version
+     */
+    @Input() public angularVersion = 'Angular 2';
 
     chartOptions: Highcharts.Options = {
         colors: [

--- a/test/src/cli/cli-generation-big-app.spec.ts
+++ b/test/src/cli/cli-generation-big-app.spec.ts
@@ -328,9 +328,15 @@ describe('CLI simple generation - big app', () => {
         expect(todoStoreFile).to.contain('code><a href="../classes/Todo.html" target="_self" >To');
     });
 
-    it('should have inherreturn type', () => {
+    it('should have inherit return type', () => {
         expect(todoClassFile).to.contain(
             'code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/number"'
+        );
+    });
+
+    it('should have inherit input type', () => {
+        expect(aboutComponentFile).to.contain(
+            'code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string"'
         );
     });
 


### PR DESCRIPTION
This commit adds support to extract inferred types on Angular
input attributes. E.g. `@Input() name = ''`

Closes #896