### PR TITLE
Feat: read jsdoc deprecated

### DIFF
--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -878,6 +878,15 @@ export class AngularDependencies extends FrameworkDependencies {
         }
     }
 
+    private checkForDeprecation(tags: any[], result: { [key in string | number]: any }) {
+        _.forEach(tags, tag => {
+            if (tag.tagName && tag.tagName.text && tag.tagName.text.indexOf('deprecated') > -1) {
+                result.deprecated = true;
+                result.deprecationMessage = tag.comment || '';
+            }
+        });
+    }
+
     private findExpressionByNameInExpressions(entryNode, name) {
         let result;
         let loop = function (node, z) {
@@ -1054,20 +1063,9 @@ export class AngularDependencies extends FrameworkDependencies {
         };
         let jsdoctags = this.jsdocParserUtil.getJSDocs(node);
 
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                result.deprecated = true;
-                                result.deprecationMessage = tag.comment || '';
-                            }
-                        }
-                    }
-                });
-                result.jsdoctags = markedtags(jsdoctags[0].tags);
-            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
+            result.jsdoctags = markedtags(jsdoctags[0].tags);
         }
         return result;
     }
@@ -1096,19 +1094,8 @@ export class AngularDependencies extends FrameworkDependencies {
         }
         let jsdoctags = this.jsdocParserUtil.getJSDocs(arg);
 
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                result.deprecated = true;
-                                result.deprecationMessage = tag.comment || '';
-                            }
-                        }
-                    }
-                });
-            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
         }
         return result;
     }
@@ -1175,29 +1162,18 @@ export class AngularDependencies extends FrameworkDependencies {
                 }
             }
         }
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                result.deprecated = true;
-                                result.deprecationMessage = tag.comment || '';
-                            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
+            result.jsdoctags = markedtags(jsdoctags[0].tags);
+            _.forEach(jsdoctags[0].tags, tag => {
+                if (tag.tagName) {
+                    if (tag.tagName.text) {
+                        if (tag.tagName.text.indexOf('ignore') > -1) {
+                            result.ignore = true;
                         }
                     }
-                });
-                result.jsdoctags = markedtags(jsdoctags[0].tags);
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('ignore') > -1) {
-                                result.ignore = true;
-                            }
-                        }
-                    }
-                });
-            }
+                }
+            });
         }
         if (result.jsdoctags && result.jsdoctags.length > 0) {
             result.jsdoctags = mergeTagsAndArgs(result.args, result.jsdoctags);
@@ -1236,19 +1212,8 @@ export class AngularDependencies extends FrameworkDependencies {
                 let jsdoctags = this.jsdocParserUtil.getJSDocs(
                     node.declarationList.declarations[i]
                 );
-                if (jsdoctags && jsdoctags.length >= 1) {
-                    if (jsdoctags[0].tags) {
-                        _.forEach(jsdoctags[0].tags, tag => {
-                            if (tag.tagName) {
-                                if (tag.tagName.text) {
-                                    if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                        result.deprecated = true;
-                                        result.deprecationMessage = tag.comment || '';
-                                    }
-                                }
-                            }
-                        });
-                    }
+                if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+                    this.checkForDeprecation(jsdoctags[0].tags, result);
                 }
                 return result;
             }
@@ -1299,37 +1264,15 @@ export class AngularDependencies extends FrameworkDependencies {
                     member.value = node.members[i].initializer.text;
                 }
                 memberjsdoctags = this.jsdocParserUtil.getJSDocs(node.members[i]);
-                if (memberjsdoctags && memberjsdoctags.length >= 1) {
-                    if (memberjsdoctags[0].tags) {
-                        _.forEach(memberjsdoctags[0].tags, tag => {
-                            if (tag.tagName) {
-                                if (tag.tagName.text) {
-                                    if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                        member.deprecated = true;
-                                        member.deprecationMessage = tag.comment || '';
-                                    }
-                                }
-                            }
-                        });
-                    }
+                if (memberjsdoctags && memberjsdoctags.length >= 1 && memberjsdoctags[0].tags) {
+                    this.checkForDeprecation(memberjsdoctags[0].tags, member);
                 }
                 result.members.push(member);
             }
         }
         let jsdoctags = this.jsdocParserUtil.getJSDocs(node);
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                result.deprecated = true;
-                                result.deprecationMessage = tag.comment || '';
-                            }
-                        }
-                    }
-                });
-            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
         }
         return result;
     }

--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -201,14 +201,13 @@ export class AngularDependencies extends FrameworkDependencies {
         let name = this.getSymboleName(node);
         let IO = this.getClassIO(file, srcFile, node, fileBody);
         let sourceCode = srcFile.getText();
-        let hash = crypto
-            .createHash('md5')
-            .update(sourceCode)
-            .digest('hex');
+        let hash = crypto.createHash('md5').update(sourceCode).digest('hex');
         let deps: any = {
             name,
             id: 'class-' + name + '-' + hash,
             file: file,
+            deprecated: IO.deprecated,
+            deprecationMessage: IO.deprecationMessage,
             type: 'class',
             sourceCode: srcFile.getText()
         };
@@ -334,10 +333,7 @@ export class AngularDependencies extends FrameworkDependencies {
             }
             let parseNode = (file, srcFile, node, fileBody) => {
                 let sourceCode = srcFile.getText();
-                let hash = crypto
-                    .createHash('md5')
-                    .update(sourceCode)
-                    .digest('hex');
+                let hash = crypto.createHash('md5').update(sourceCode).digest('hex');
 
                 if (node.decorators) {
                     let classWithCustomDecorator = false;
@@ -400,6 +396,8 @@ export class AngularDependencies extends FrameworkDependencies {
                                 file: file,
                                 properties: IO.properties,
                                 methods: IO.methods,
+                                deprecated: IO.deprecated,
+                                deprecationMessage: IO.deprecationMessage,
                                 description: IO.description,
                                 rawdescription: IO.rawdescription,
                                 sourceCode: srcFile.getText(),
@@ -441,6 +439,8 @@ export class AngularDependencies extends FrameworkDependencies {
                                 id: 'pipe-' + name + '-' + hash,
                                 file: file,
                                 type: 'pipe',
+                                deprecated: IO.deprecated,
+                                deprecationMessage: IO.deprecationMessage,
                                 description: IO.description,
                                 rawdescription: IO.rawdescription,
                                 properties: IO.properties,
@@ -519,6 +519,8 @@ export class AngularDependencies extends FrameworkDependencies {
                             name,
                             id: 'interface-' + name + '-' + hash,
                             file: file,
+                            deprecated: IO.deprecated,
+                            deprecationMessage: IO.deprecationMessage,
                             type: 'interface',
                             sourceCode: srcFile.getText()
                         };
@@ -551,11 +553,15 @@ export class AngularDependencies extends FrameworkDependencies {
                         let infos = this.visitFunctionDeclaration(node);
                         // let tags = this.visitFunctionDeclarationJSDocTags(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let functionDep: IFunctionDecDep = {
                             name,
                             file: file,
                             ctype: 'miscellaneous',
                             subtype: 'function',
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (infos.args) {
@@ -579,12 +585,16 @@ export class AngularDependencies extends FrameworkDependencies {
                         }
                     } else if (ts.isEnumDeclaration(node)) {
                         let infos = this.visitEnumDeclaration(node);
-                        let name = node.name.text;
+                        let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let enumDeps: IEnumDecDep = {
                             name,
-                            childs: infos,
+                            childs: infos.members,
                             ctype: 'miscellaneous',
                             subtype: 'enum',
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(
                                 node
                             ),
@@ -596,12 +606,16 @@ export class AngularDependencies extends FrameworkDependencies {
                     } else if (ts.isTypeAliasDeclaration(node)) {
                         let infos = this.visitTypeDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let typeAliasDeps: ITypeAliasDecDep = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'typealias',
                             rawtype: this.classHelper.visitType(node),
                             file: file,
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (node.type) {
@@ -706,11 +720,15 @@ export class AngularDependencies extends FrameworkDependencies {
                     if (ts.isVariableStatement(node) && !RouterParserUtil.isVariableRoutes(node)) {
                         let infos: any = this.visitVariableDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let deps: any = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'variable',
-                            file: file
+                            file: file,
+                            deprecated,
+                            deprecationMessage
                         };
                         deps.type = infos.type ? infos.type : '';
                         if (infos.defaultValue) {
@@ -736,12 +754,16 @@ export class AngularDependencies extends FrameworkDependencies {
                     if (ts.isTypeAliasDeclaration(node)) {
                         let infos = this.visitTypeDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let deps: ITypeAliasDecDep = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'typealias',
                             rawtype: this.classHelper.visitType(node),
                             file: file,
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (node.type) {
@@ -754,11 +776,15 @@ export class AngularDependencies extends FrameworkDependencies {
                     if (ts.isFunctionDeclaration(node)) {
                         let infos = this.visitFunctionDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let functionDep: IFunctionDecDep = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'function',
                             file: file,
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (infos.args) {
@@ -783,12 +809,16 @@ export class AngularDependencies extends FrameworkDependencies {
                     }
                     if (ts.isEnumDeclaration(node)) {
                         let infos = this.visitEnumDeclaration(node);
-                        let name = node.name.text;
+                        let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let enumDeps: IEnumDecDep = {
                             name,
-                            childs: infos,
+                            childs: infos.members,
                             ctype: 'miscellaneous',
                             subtype: 'enum',
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(
                                 node
                             ),
@@ -850,7 +880,7 @@ export class AngularDependencies extends FrameworkDependencies {
 
     private findExpressionByNameInExpressions(entryNode, name) {
         let result;
-        let loop = function(node, z) {
+        let loop = function (node, z) {
             if (node) {
                 if (node.expression && !node.expression.name) {
                     loop(node.expression, z);
@@ -873,7 +903,7 @@ export class AngularDependencies extends FrameworkDependencies {
         let that = this;
         let i = 0;
         let len = arg.length;
-        let loop = function(node, z) {
+        let loop = function (node, z) {
             if (node.body) {
                 if (node.body.statements && node.body.statements.length > 0) {
                     let j = 0;
@@ -893,7 +923,7 @@ export class AngularDependencies extends FrameworkDependencies {
     private parseDecorators(decorators, type: string): boolean {
         let result = false;
         if (decorators.length > 1) {
-            _.forEach(decorators, function(decorator: any) {
+            _.forEach(decorators, function (decorator: any) {
                 if (decorator.expression.expression) {
                     if (decorator.expression.expression.text === type) {
                         result = true;
@@ -1017,6 +1047,8 @@ export class AngularDependencies extends FrameworkDependencies {
 
     private visitTypeDeclaration(node: ts.TypeAliasDeclaration) {
         let result: any = {
+            deprecated: false,
+            deprecationMessage: '',
             name: node.name.text,
             kind: node.kind
         };
@@ -1024,6 +1056,16 @@ export class AngularDependencies extends FrameworkDependencies {
 
         if (jsdoctags && jsdoctags.length >= 1) {
             if (jsdoctags[0].tags) {
+                _.forEach(jsdoctags[0].tags, tag => {
+                    if (tag.tagName) {
+                        if (tag.tagName.text) {
+                            if (tag.tagName.text.indexOf('deprecated') > -1) {
+                                result.deprecated = true;
+                                result.deprecationMessage = tag.comment || '';
+                            }
+                        }
+                    }
+                });
                 result.jsdoctags = markedtags(jsdoctags[0].tags);
             }
         }
@@ -1033,7 +1075,9 @@ export class AngularDependencies extends FrameworkDependencies {
     private visitArgument(arg) {
         let result: any = {
             name: arg.name.text,
-            type: this.classHelper.visitType(arg)
+            type: this.classHelper.visitType(arg),
+            deprecated: false,
+            deprecationMessage: ''
         };
         if (arg.dotDotDotToken) {
             result.dotDotDotToken = true;
@@ -1048,6 +1092,22 @@ export class AngularDependencies extends FrameworkDependencies {
                 if (arg.type.typeName) {
                     result.type = arg.type.typeName.text;
                 }
+            }
+        }
+        let jsdoctags = this.jsdocParserUtil.getJSDocs(arg);
+
+        if (jsdoctags && jsdoctags.length >= 1) {
+            if (jsdoctags[0].tags) {
+                _.forEach(jsdoctags[0].tags, tag => {
+                    if (tag.tagName) {
+                        if (tag.tagName.text) {
+                            if (tag.tagName.text.indexOf('deprecated') > -1) {
+                                result.deprecated = true;
+                                result.deprecationMessage = tag.comment || '';
+                            }
+                        }
+                    }
+                });
             }
         }
         return result;
@@ -1089,6 +1149,8 @@ export class AngularDependencies extends FrameworkDependencies {
     private visitFunctionDeclaration(method: ts.FunctionDeclaration) {
         let methodName = method.name ? method.name.text : 'Unnamed function';
         let result: any = {
+            deprecated: false,
+            deprecationMessage: '',
             name: methodName,
             args: method.parameters ? method.parameters.map(prop => this.visitArgument(prop)) : []
         };
@@ -1115,6 +1177,16 @@ export class AngularDependencies extends FrameworkDependencies {
         }
         if (jsdoctags && jsdoctags.length >= 1) {
             if (jsdoctags[0].tags) {
+                _.forEach(jsdoctags[0].tags, tag => {
+                    if (tag.tagName) {
+                        if (tag.tagName.text) {
+                            if (tag.tagName.text.indexOf('deprecated') > -1) {
+                                result.deprecated = true;
+                                result.deprecationMessage = tag.comment || '';
+                            }
+                        }
+                    }
+                });
                 result.jsdoctags = markedtags(jsdoctags[0].tags);
                 _.forEach(jsdoctags[0].tags, tag => {
                     if (tag.tagName) {
@@ -1146,7 +1218,9 @@ export class AngularDependencies extends FrameworkDependencies {
                         ? this.classHelper.stringifyDefaultValue(
                               node.declarationList.declarations[i].initializer
                           )
-                        : undefined
+                        : undefined,
+                    deprecated: false,
+                    deprecationMessage: ''
                 };
                 if (node.declarationList.declarations[i].initializer) {
                     result.initializer = node.declarationList.declarations[i].initializer;
@@ -1158,6 +1232,23 @@ export class AngularDependencies extends FrameworkDependencies {
                 }
                 if (typeof result.type === 'undefined' && result.initializer) {
                     result.type = kindToType(result.initializer.kind);
+                }
+                let jsdoctags = this.jsdocParserUtil.getJSDocs(
+                    node.declarationList.declarations[i]
+                );
+                if (jsdoctags && jsdoctags.length >= 1) {
+                    if (jsdoctags[0].tags) {
+                        _.forEach(jsdoctags[0].tags, tag => {
+                            if (tag.tagName) {
+                                if (tag.tagName.text) {
+                                    if (tag.tagName.text.indexOf('deprecated') > -1) {
+                                        result.deprecated = true;
+                                        result.deprecationMessage = tag.comment || '';
+                                    }
+                                }
+                            }
+                        });
+                    }
                 }
                 return result;
             }
@@ -1188,18 +1279,56 @@ export class AngularDependencies extends FrameworkDependencies {
     }
 
     private visitEnumDeclaration(node: ts.EnumDeclaration) {
-        let result = [];
+        let result: any = {
+            deprecated: false,
+            deprecationMessage: '',
+            name: node.name.text,
+            members: []
+        };
         if (node.members) {
             let i = 0;
             let len = node.members.length;
+            let memberjsdoctags = [];
             for (i; i < len; i++) {
                 let member: any = {
-                    name: node.members[i].name.text
+                    name: node.members[i].name.text,
+                    deprecated: false,
+                    deprecationMessage: ''
                 };
                 if (node.members[i].initializer) {
                     member.value = node.members[i].initializer.text;
                 }
-                result.push(member);
+                memberjsdoctags = this.jsdocParserUtil.getJSDocs(node.members[i]);
+                if (memberjsdoctags && memberjsdoctags.length >= 1) {
+                    if (memberjsdoctags[0].tags) {
+                        _.forEach(memberjsdoctags[0].tags, tag => {
+                            if (tag.tagName) {
+                                if (tag.tagName.text) {
+                                    if (tag.tagName.text.indexOf('deprecated') > -1) {
+                                        member.deprecated = true;
+                                        member.deprecationMessage = tag.comment || '';
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+                result.members.push(member);
+            }
+        }
+        let jsdoctags = this.jsdocParserUtil.getJSDocs(node);
+        if (jsdoctags && jsdoctags.length >= 1) {
+            if (jsdoctags[0].tags) {
+                _.forEach(jsdoctags[0].tags, tag => {
+                    if (tag.tagName) {
+                        if (tag.tagName.text) {
+                            if (tag.tagName.text.indexOf('deprecated') > -1) {
+                                result.deprecated = true;
+                                result.deprecationMessage = tag.comment || '';
+                            }
+                        }
+                    }
+                });
             }
         }
         return result;

--- a/src/app/compiler/angular/dependencies.interfaces.ts
+++ b/src/app/compiler/angular/dependencies.interfaces.ts
@@ -9,6 +9,8 @@ export interface IInjectableDep extends IDep {
     file: any;
     properties: Array<any>;
     methods: Array<any>;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     rawdescription: string;
     sourceCode: string;
@@ -24,6 +26,8 @@ export interface IInterceptorDep extends IDep {
     file: any;
     properties: Array<any>;
     methods: Array<any>;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     sourceCode: string;
 
@@ -36,6 +40,8 @@ export interface IGuardDep extends IDep {
     file: any;
     properties: Array<any>;
     methods: Array<any>;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     sourceCode: string;
 
@@ -46,6 +52,8 @@ export interface IGuardDep extends IDep {
 
 export interface IPipeDep extends IDep {
     file: any;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     rawdescription: string;
     sourceCode: string;
@@ -66,6 +74,8 @@ export interface IInterfaceDep extends IDep {
     properties?: Array<any>;
     indexSignatures?: any;
     kind?: any;
+    deprecated: boolean;
+    deprecationMessage: string;
     description?: string;
     rawdescription?: string;
     methods?: Array<any>;
@@ -75,6 +85,8 @@ export interface IInterfaceDep extends IDep {
 export interface IFunctionDecDep extends IDep {
     file: any;
     subtype: string;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
 
     returnType?: string;
@@ -85,6 +97,8 @@ export interface IFunctionDecDep extends IDep {
 export interface IEnumDecDep extends IDep {
     childs: Array<any>;
     subtype: string;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     file: any;
 }
@@ -93,6 +107,8 @@ export interface ITypeAliasDecDep extends IDep {
     subtype: string;
     file: any;
     rawtype: any;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
 
     kind?;
@@ -108,6 +124,8 @@ export interface Deps {
     label?: string;
     file?: string;
     sourceCode?: string;
+    deprecated?: boolean;
+    deprecationMessage?: string;
     description?: string;
 
     // Component

--- a/src/app/compiler/angular/deps/helpers/class-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/class-helper.ts
@@ -40,6 +40,15 @@ export class ClassHelper {
         }
     }
 
+    private checkForDeprecation(tags: any[], result: { [key in string | number]: any }) {
+        _.forEach(tags, tag => {
+            if (tag.tagName && tag.tagName.text && tag.tagName.text.indexOf('deprecated') > -1) {
+                result.deprecated = true;
+                result.deprecationMessage = tag.comment || '';
+            }
+        });
+    }
+
     private getDecoratorOfType(node, decoratorType) {
         let decorators = node.decorators || [];
 
@@ -249,20 +258,9 @@ export class ClassHelper {
                     }
                 }
 
-                if (jsdoctags && jsdoctags.length >= 1) {
-                    if (jsdoctags[0].tags) {
-                        _.forEach(jsdoctags[0].tags, tag => {
-                            if (tag.tagName) {
-                                if (tag.tagName.text) {
-                                    if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                        setSignature.deprecated = true;
-                                        setSignature.deprecationMessage = tag.comment || '';
-                                    }
-                                }
-                            }
-                        });
-                        setSignature.jsdoctags = markedtags(jsdoctags[0].tags);
-                    }
+                if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+                    this.checkForDeprecation(jsdoctags[0].tags, setSignature);
+                    setSignature.jsdoctags = markedtags(jsdoctags[0].tags);
                 }
                 if (setSignature.jsdoctags && setSignature.jsdoctags.length > 0) {
                     setSignature.jsdoctags = mergeTagsAndArgs(
@@ -431,19 +429,15 @@ export class ClassHelper {
             }
             if (symbol.declarations && symbol.declarations.length > 0) {
                 let declarationsjsdoctags = this.jsdocParserUtil.getJSDocs(symbol.declarations[0]);
-                if (declarationsjsdoctags && declarationsjsdoctags.length >= 1) {
-                    if (declarationsjsdoctags[0].tags) {
-                        _.forEach(declarationsjsdoctags[0].tags, tag => {
-                            if (tag.tagName) {
-                                if (tag.tagName.text) {
-                                    if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                        deprecated = true;
-                                        deprecationMessage = tag.comment || '';
-                                    }
-                                }
-                            }
-                        });
-                    }
+                if (
+                    declarationsjsdoctags &&
+                    declarationsjsdoctags.length >= 1 &&
+                    declarationsjsdoctags[0].tags
+                ) {
+                    const deprecation = { deprecated: false, deprecationMessage: '' };
+                    this.checkForDeprecation(declarationsjsdoctags[0].tags, deprecation);
+                    deprecated = deprecation.deprecated;
+                    deprecationMessage = deprecation.deprecationMessage;
                 }
                 if (isIgnore(symbol.declarations[0])) {
                     return [{ ignore: true }];
@@ -451,20 +445,12 @@ export class ClassHelper {
             }
             if (symbol.valueDeclaration) {
                 jsdoctags = this.jsdocParserUtil.getJSDocs(symbol.valueDeclaration);
-                if (jsdoctags && jsdoctags.length >= 1) {
-                    if (jsdoctags[0].tags) {
-                        _.forEach(jsdoctags[0].tags, tag => {
-                            if (tag.tagName) {
-                                if (tag.tagName.text) {
-                                    if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                        deprecated = true;
-                                        deprecationMessage = tag.comment || '';
-                                    }
-                                }
-                            }
-                        });
-                        jsdoctags = markedtags(jsdoctags[0].tags);
-                    }
+                if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+                    const deprecation = { deprecated: false, deprecationMessage: '' };
+                    this.checkForDeprecation(jsdoctags[0].tags, deprecation);
+                    deprecated = deprecation.deprecated;
+                    deprecationMessage = deprecation.deprecationMessage;
+                    jsdoctags = markedtags(jsdoctags[0].tags);
                 }
             }
         }
@@ -991,20 +977,9 @@ export class ClassHelper {
                 result.modifierKind = kinds;
             }
         }
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                result.deprecated = true;
-                                result.deprecationMessage = tag.comment || '';
-                            }
-                        }
-                    }
-                });
-                result.jsdoctags = markedtags(jsdoctags[0].tags);
-            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
+            result.jsdoctags = markedtags(jsdoctags[0].tags);
         }
         if (result.jsdoctags && result.jsdoctags.length > 0) {
             result.jsdoctags = mergeTagsAndArgs(result.args, result.jsdoctags);
@@ -1063,21 +1038,10 @@ export class ClassHelper {
                 result.modifierKind = kinds;
             }
         }
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                result.deprecated = true;
-                                result.deprecationMessage = tag.comment || '';
-                            }
-                        }
-                    }
-                });
-                if (property.jsDoc) {
-                    result.jsdoctags = markedtags(jsdoctags[0].tags);
-                }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
+            if (property.jsDoc) {
+                result.jsdoctags = markedtags(jsdoctags[0].tags);
             }
         }
 
@@ -1141,20 +1105,9 @@ export class ClassHelper {
                 if (property.jsDoc.length > 0) {
                     const jsdoctags = this.jsdocParserUtil.getJSDocs(property);
 
-                    if (jsdoctags && jsdoctags.length >= 1) {
-                        if (jsdoctags[0].tags) {
-                            _.forEach(jsdoctags[0].tags, tag => {
-                                if (tag.tagName) {
-                                    if (tag.tagName.text) {
-                                        if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                            _return.deprecated = true;
-                                            _return.deprecationMessage = tag.comment || '';
-                                        }
-                                    }
-                                }
-                            });
-                            _return.jsdoctags = markedtags(jsdoctags[0].tags);
-                        }
+                    if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+                        this.checkForDeprecation(jsdoctags[0].tags, _return);
+                        _return.jsdoctags = markedtags(jsdoctags[0].tags);
                     }
                     if (typeof property.jsDoc[0].comment !== 'undefined') {
                         const rawDescription = property.jsDoc[0].comment;
@@ -1284,20 +1237,9 @@ export class ClassHelper {
             _return.rawdescription = rawDescription;
             _return.description = marked(rawDescription);
 
-            if (jsdoctags && jsdoctags.length >= 1) {
-                if (jsdoctags[0].tags) {
-                    _.forEach(jsdoctags[0].tags, tag => {
-                        if (tag.tagName) {
-                            if (tag.tagName.text) {
-                                if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                    _return.deprecated = true;
-                                    _return.deprecationMessage = tag.comment || '';
-                                }
-                            }
-                        }
-                    });
-                    _return.jsdoctags = markedtags(jsdoctags[0].tags);
-                }
+            if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+                this.checkForDeprecation(jsdoctags[0].tags, _return);
+                _return.jsdoctags = markedtags(jsdoctags[0].tags);
             }
         }
         if (!_return.description) {
@@ -1352,19 +1294,8 @@ export class ClassHelper {
             _result.defaultValue = this.stringifyDefaultValue(arg.initializer);
         }
         const jsdoctags = this.jsdocParserUtil.getJSDocs(arg);
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                _result.deprecated = true;
-                                _result.deprecationMessage = tag.comment || '';
-                            }
-                        }
-                    }
-                });
-            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, _result);
         }
         return _result;
     }
@@ -1391,20 +1322,9 @@ export class ClassHelper {
             _return.rawdescription = rawDescription;
             _return.description = marked(rawDescription);
 
-            if (jsdoctags && jsdoctags.length >= 1) {
-                if (jsdoctags[0].tags) {
-                    _.forEach(jsdoctags[0].tags, tag => {
-                        if (tag.tagName) {
-                            if (tag.tagName.text) {
-                                if (tag.tagName.text.indexOf('deprecated') > -1) {
-                                    _return.deprecated = true;
-                                    _return.deprecationMessage = tag.comment || '';
-                                }
-                            }
-                        }
-                    });
-                    _return.jsdoctags = markedtags(jsdoctags[0].tags);
-                }
+            if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+                this.checkForDeprecation(jsdoctags[0].tags, _return);
+                _return.jsdoctags = markedtags(jsdoctags[0].tags);
             }
         }
         if (!_return.description) {

--- a/test/src/cli/cli-export.spec.ts
+++ b/test/src/cli/cli-export.spec.ts
@@ -48,7 +48,7 @@ describe('CLI Export', () => {
 
             // pipe
             expect(file).to.contain(
-                '"rawdescription": "Uppercase the first letter of the string\\r\\n\\r\\n__Usage :__\\r\\n   value | firstUpper"'
+                '"rawdescription": "Uppercase the first letter of the string\\n\\n__Usage :__\\n   value | firstUpper"'
             );
             expect(file).to.contain(
                 '"description": "<p>Uppercase the first letter of the string</p>\\n<p><strong>Usage :</strong>\\n   value | firstUpper</p>\\n"'
@@ -64,7 +64,7 @@ describe('CLI Export', () => {
 
             // service
             expect(file).to.contain(
-                '"rawdescription": "This service is a todo store\\r\\nSee {@link Todo} for details about the main data of this store"'
+                '"rawdescription": "This service is a todo store\\nSee {@link Todo} for details about the main data of this store"'
             );
             expect(file).to.contain(
                 '"description": "<p>This service is a todo store\\nSee {@link Todo} for details about the main data of this store</p>\\n"'


### PR DESCRIPTION
partly closes #937
Parses the @deprecated jsdoc tag so it can at least be used with the JSON output file, which is required by our team.
Can now more easily be further implemented so it is also displayed.