### PR TITLE
feat: read jsdoc deprecated

### DIFF
--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -206,6 +206,8 @@ export class AngularDependencies extends FrameworkDependencies {
             name,
             id: 'class-' + name + '-' + hash,
             file: file,
+            deprecated: IO.deprecated,
+            deprecationMessage: IO.deprecationMessage,
             type: 'class',
             sourceCode: srcFile.getText()
         };
@@ -394,6 +396,8 @@ export class AngularDependencies extends FrameworkDependencies {
                                 file: file,
                                 properties: IO.properties,
                                 methods: IO.methods,
+                                deprecated: IO.deprecated,
+                                deprecationMessage: IO.deprecationMessage,
                                 description: IO.description,
                                 rawdescription: IO.rawdescription,
                                 sourceCode: srcFile.getText(),
@@ -435,6 +439,8 @@ export class AngularDependencies extends FrameworkDependencies {
                                 id: 'pipe-' + name + '-' + hash,
                                 file: file,
                                 type: 'pipe',
+                                deprecated: IO.deprecated,
+                                deprecationMessage: IO.deprecationMessage,
                                 description: IO.description,
                                 rawdescription: IO.rawdescription,
                                 properties: IO.properties,
@@ -518,6 +524,8 @@ export class AngularDependencies extends FrameworkDependencies {
                             name,
                             id: 'interface-' + name + '-' + hash,
                             file: file,
+                            deprecated: IO.deprecated,
+                            deprecationMessage: IO.deprecationMessage,
                             type: 'interface',
                             sourceCode: srcFile.getText()
                         };
@@ -550,11 +558,15 @@ export class AngularDependencies extends FrameworkDependencies {
                         let infos = this.visitFunctionDeclaration(node);
                         // let tags = this.visitFunctionDeclarationJSDocTags(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let functionDep: IFunctionDecDep = {
                             name,
                             file: file,
                             ctype: 'miscellaneous',
                             subtype: 'function',
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (infos.args) {
@@ -578,12 +590,16 @@ export class AngularDependencies extends FrameworkDependencies {
                         }
                     } else if (ts.isEnumDeclaration(node)) {
                         let infos = this.visitEnumDeclaration(node);
-                        let name = node.name.text;
+                        let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let enumDeps: IEnumDecDep = {
                             name,
-                            childs: infos,
+                            childs: infos.members,
                             ctype: 'miscellaneous',
                             subtype: 'enum',
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(
                                 node
                             ),
@@ -595,12 +611,16 @@ export class AngularDependencies extends FrameworkDependencies {
                     } else if (ts.isTypeAliasDeclaration(node)) {
                         let infos = this.visitTypeDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let typeAliasDeps: ITypeAliasDecDep = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'typealias',
                             rawtype: this.classHelper.visitType(node),
                             file: file,
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (node.type) {
@@ -709,11 +729,15 @@ export class AngularDependencies extends FrameworkDependencies {
                     if (ts.isVariableStatement(node) && !RouterParserUtil.isVariableRoutes(node)) {
                         let infos: any = this.visitVariableDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let deps: any = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'variable',
-                            file: file
+                            file: file,
+                            deprecated,
+                            deprecationMessage
                         };
                         deps.type = infos.type ? infos.type : '';
                         if (infos.defaultValue) {
@@ -739,12 +763,16 @@ export class AngularDependencies extends FrameworkDependencies {
                     if (ts.isTypeAliasDeclaration(node)) {
                         let infos = this.visitTypeDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let deps: ITypeAliasDecDep = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'typealias',
                             rawtype: this.classHelper.visitType(node),
                             file: file,
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (node.type) {
@@ -757,11 +785,15 @@ export class AngularDependencies extends FrameworkDependencies {
                     if (ts.isFunctionDeclaration(node)) {
                         let infos = this.visitFunctionDeclaration(node);
                         let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let functionDep: IFunctionDecDep = {
                             name,
                             ctype: 'miscellaneous',
                             subtype: 'function',
                             file: file,
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(node)
                         };
                         if (infos.args) {
@@ -786,12 +818,16 @@ export class AngularDependencies extends FrameworkDependencies {
                     }
                     if (ts.isEnumDeclaration(node)) {
                         let infos = this.visitEnumDeclaration(node);
-                        let name = node.name.text;
+                        let name = infos.name;
+                        let deprecated = infos.deprecated;
+                        let deprecationMessage = infos.deprecationMessage;
                         let enumDeps: IEnumDecDep = {
                             name,
-                            childs: infos,
+                            childs: infos.members,
                             ctype: 'miscellaneous',
                             subtype: 'enum',
+                            deprecated,
+                            deprecationMessage,
                             description: this.visitEnumTypeAliasFunctionDeclarationDescription(
                                 node
                             ),
@@ -849,6 +885,15 @@ export class AngularDependencies extends FrameworkDependencies {
         } else {
             return;
         }
+    }
+
+    private checkForDeprecation(tags: any[], result: { [key in string | number]: any }) {
+        _.forEach(tags, tag => {
+            if (tag.tagName && tag.tagName.text && tag.tagName.text.indexOf('deprecated') > -1) {
+                result.deprecated = true;
+                result.deprecationMessage = tag.comment || '';
+            }
+        });
     }
 
     private findExpressionByNameInExpressions(entryNode, name) {
@@ -1020,15 +1065,16 @@ export class AngularDependencies extends FrameworkDependencies {
 
     private visitTypeDeclaration(node: ts.TypeAliasDeclaration) {
         let result: any = {
+            deprecated: false,
+            deprecationMessage: '',
             name: node.name.text,
             kind: node.kind
         };
         let jsdoctags = this.jsdocParserUtil.getJSDocs(node);
 
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                result.jsdoctags = markedtags(jsdoctags[0].tags);
-            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
+            result.jsdoctags = markedtags(jsdoctags[0].tags);
         }
         return result;
     }
@@ -1036,7 +1082,9 @@ export class AngularDependencies extends FrameworkDependencies {
     private visitArgument(arg) {
         let result: any = {
             name: arg.name.text,
-            type: this.classHelper.visitType(arg)
+            type: this.classHelper.visitType(arg),
+            deprecated: false,
+            deprecationMessage: ''
         };
         if (arg.dotDotDotToken) {
             result.dotDotDotToken = true;
@@ -1052,6 +1100,11 @@ export class AngularDependencies extends FrameworkDependencies {
                     result.type = arg.type.typeName.text;
                 }
             }
+        }
+        let jsdoctags = this.jsdocParserUtil.getJSDocs(arg);
+
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
         }
         return result;
     }
@@ -1092,6 +1145,8 @@ export class AngularDependencies extends FrameworkDependencies {
     private visitFunctionDeclaration(method: ts.FunctionDeclaration) {
         let methodName = method.name ? method.name.text : 'Unnamed function';
         let result: any = {
+            deprecated: false,
+            deprecationMessage: '',
             name: methodName,
             args: method.parameters ? method.parameters.map(prop => this.visitArgument(prop)) : []
         };
@@ -1116,19 +1171,18 @@ export class AngularDependencies extends FrameworkDependencies {
                 }
             }
         }
-        if (jsdoctags && jsdoctags.length >= 1) {
-            if (jsdoctags[0].tags) {
-                result.jsdoctags = markedtags(jsdoctags[0].tags);
-                _.forEach(jsdoctags[0].tags, tag => {
-                    if (tag.tagName) {
-                        if (tag.tagName.text) {
-                            if (tag.tagName.text.indexOf('ignore') > -1) {
-                                result.ignore = true;
-                            }
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
+            result.jsdoctags = markedtags(jsdoctags[0].tags);
+            _.forEach(jsdoctags[0].tags, tag => {
+                if (tag.tagName) {
+                    if (tag.tagName.text) {
+                        if (tag.tagName.text.indexOf('ignore') > -1) {
+                            result.ignore = true;
                         }
                     }
-                });
-            }
+                }
+            });
         }
         if (result.jsdoctags && result.jsdoctags.length > 0) {
             result.jsdoctags = mergeTagsAndArgs(result.args, result.jsdoctags);
@@ -1149,7 +1203,9 @@ export class AngularDependencies extends FrameworkDependencies {
                         ? this.classHelper.stringifyDefaultValue(
                               node.declarationList.declarations[i].initializer
                           )
-                        : undefined
+                        : undefined,
+                    deprecated: false,
+                    deprecationMessage: ''
                 };
                 if (node.declarationList.declarations[i].initializer) {
                     result.initializer = node.declarationList.declarations[i].initializer;
@@ -1161,6 +1217,12 @@ export class AngularDependencies extends FrameworkDependencies {
                 }
                 if (typeof result.type === 'undefined' && result.initializer) {
                     result.type = kindToType(result.initializer.kind);
+                }
+                let jsdoctags = this.jsdocParserUtil.getJSDocs(
+                    node.declarationList.declarations[i]
+                );
+                if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+                    this.checkForDeprecation(jsdoctags[0].tags, result);
                 }
                 return result;
             }
@@ -1191,19 +1253,35 @@ export class AngularDependencies extends FrameworkDependencies {
     }
 
     private visitEnumDeclaration(node: ts.EnumDeclaration) {
-        let result = [];
+        let result: any = {
+            deprecated: false,
+            deprecationMessage: '',
+            name: node.name.text,
+            members: []
+        };
         if (node.members) {
             let i = 0;
             let len = node.members.length;
+            let memberjsdoctags = [];
             for (i; i < len; i++) {
                 let member: any = {
-                    name: node.members[i].name.text
+                    name: node.members[i].name.text,
+                    deprecated: false,
+                    deprecationMessage: ''
                 };
                 if (node.members[i].initializer) {
                     member.value = node.members[i].initializer.text;
                 }
-                result.push(member);
+                memberjsdoctags = this.jsdocParserUtil.getJSDocs(node.members[i]);
+                if (memberjsdoctags && memberjsdoctags.length >= 1 && memberjsdoctags[0].tags) {
+                    this.checkForDeprecation(memberjsdoctags[0].tags, member);
+                }
+                result.members.push(member);
             }
+        }
+        let jsdoctags = this.jsdocParserUtil.getJSDocs(node);
+        if (jsdoctags && jsdoctags.length >= 1 && jsdoctags[0].tags) {
+            this.checkForDeprecation(jsdoctags[0].tags, result);
         }
         return result;
     }

--- a/src/app/compiler/angular/dependencies.interfaces.ts
+++ b/src/app/compiler/angular/dependencies.interfaces.ts
@@ -9,6 +9,8 @@ export interface IInjectableDep extends IDep {
     file: any;
     properties: Array<any>;
     methods: Array<any>;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     rawdescription: string;
     sourceCode: string;
@@ -24,6 +26,8 @@ export interface IInterceptorDep extends IDep {
     file: any;
     properties: Array<any>;
     methods: Array<any>;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     sourceCode: string;
 
@@ -36,6 +40,8 @@ export interface IGuardDep extends IDep {
     file: any;
     properties: Array<any>;
     methods: Array<any>;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     sourceCode: string;
 
@@ -46,6 +52,8 @@ export interface IGuardDep extends IDep {
 
 export interface IPipeDep extends IDep {
     file: any;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     rawdescription: string;
     sourceCode: string;
@@ -66,6 +74,8 @@ export interface IInterfaceDep extends IDep {
     properties?: Array<any>;
     indexSignatures?: any;
     kind?: any;
+    deprecated: boolean;
+    deprecationMessage: string;
     description?: string;
     rawdescription?: string;
     methods?: Array<any>;
@@ -75,6 +85,8 @@ export interface IInterfaceDep extends IDep {
 export interface IFunctionDecDep extends IDep {
     file: any;
     subtype: string;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
 
     returnType?: string;
@@ -85,6 +97,8 @@ export interface IFunctionDecDep extends IDep {
 export interface IEnumDecDep extends IDep {
     childs: Array<any>;
     subtype: string;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
     file: any;
 }
@@ -93,6 +107,8 @@ export interface ITypeAliasDecDep extends IDep {
     subtype: string;
     file: any;
     rawtype: any;
+    deprecated: boolean;
+    deprecationMessage: string;
     description: string;
 
     kind?;
@@ -108,6 +124,8 @@ export interface Deps {
     label?: string;
     file?: string;
     sourceCode?: string;
+    deprecated?: boolean;
+    deprecationMessage?: string;
     description?: string;
 
     // Component

--- a/test/fixtures/todomvc-ng2-duplicates/src/app/shared/interfaces/clock.interface.ts
+++ b/test/fixtures/todomvc-ng2-duplicates/src/app/shared/interfaces/clock.interface.ts
@@ -14,6 +14,7 @@ interface ClockInterface extends TimeInterface {
     /**
      * The current time
      * @type {Date}
+     * @deprecated The current time property is deprecated
      */
     currentTime: Date;
     /**

--- a/test/fixtures/todomvc-ng2-duplicates/src/app/shared/pipes/first-upper.pipe.ts
+++ b/test/fixtures/todomvc-ng2-duplicates/src/app/shared/pipes/first-upper.pipe.ts
@@ -12,6 +12,7 @@ const pure = true;
  * __Example :__
  *   {{ car |  firstUpper}}
  *   formats to: Car
+ * @deprecated This pipe is deprecated
  */
 @Pipe({
     name,
@@ -25,6 +26,7 @@ export class FirstUpperPipe implements PipeTransform {
 
     /**
      * the transform function
+     * @deprecated the transform function is deprecated
      * @param  {string} value the value of the pipe
      */
     transform(value: string): string {

--- a/test/fixtures/todomvc-ng2-duplicates/src/app/shared/services/todo.store.ts
+++ b/test/fixtures/todomvc-ng2-duplicates/src/app/shared/services/todo.store.ts
@@ -6,6 +6,7 @@ import { Todo } from '../models/todo.model';
  * This service is a todo store
  * @ignore
  * See {@link Todo} for details about the main data of this store
+ * @deprecated This service is deprecated
  */
 @Injectable()
 export class TodoStore {
@@ -162,6 +163,7 @@ export class TodoStore {
 
     /**
      * Getter of _fullName
+     * @deprecated This getter is deprecated
      * @return {string} _fullName value
      */
     get fullName(): string {
@@ -170,6 +172,7 @@ export class TodoStore {
 
     /**
      * Setter of _fullName
+     * @deprecated This setter is deprecated
      * @param  {string} newName The new name
      */
     set fullName(newName: string) {

--- a/test/fixtures/todomvc-ng2-ignore/src/app/shared/interfaces/clock.interface.ts
+++ b/test/fixtures/todomvc-ng2-ignore/src/app/shared/interfaces/clock.interface.ts
@@ -14,6 +14,7 @@ interface ClockInterface extends TimeInterface {
     /**
      * The current time
      * @type {Date}
+     * @deprecated The current time property is deprecated
      */
     currentTime: Date;
     /**

--- a/test/fixtures/todomvc-ng2-ignore/src/app/shared/pipes/first-upper.pipe.ts
+++ b/test/fixtures/todomvc-ng2-ignore/src/app/shared/pipes/first-upper.pipe.ts
@@ -13,6 +13,7 @@ const pure = true;
  * __Example :__
  *   {{ car |  firstUpper}}
  *   formats to: Car
+ * @deprecated This pipe is deprecated
  */
 @Pipe({
     name,
@@ -26,6 +27,7 @@ export class FirstUpperPipe implements PipeTransform {
 
     /**
      * the transform function
+     * @deprecated the transform function is deprecated
      * @param  {string} value the value of the pipe
      */
     transform(value: string): string {

--- a/test/fixtures/todomvc-ng2-ignore/src/app/shared/services/todo.store.ts
+++ b/test/fixtures/todomvc-ng2-ignore/src/app/shared/services/todo.store.ts
@@ -6,6 +6,7 @@ import { Todo } from '../models/todo.model';
  * This service is a todo store
  * @ignore
  * See {@link Todo} for details about the main data of this store
+ * @deprecated This service is deprecated
  */
 @Injectable()
 export class TodoStore {
@@ -162,6 +163,7 @@ export class TodoStore {
 
     /**
      * Getter of _fullName
+     * @deprecated This getter is deprecated
      * @return {string} _fullName value
      */
     get fullName(): string {
@@ -170,6 +172,7 @@ export class TodoStore {
 
     /**
      * Setter of _fullName
+     * @deprecated This setter is deprecated
      * @param  {string} newName The new name
      */
     set fullName(newName: string) {

--- a/test/fixtures/todomvc-ng2/src/app/shared/interfaces/clock.interface.ts
+++ b/test/fixtures/todomvc-ng2/src/app/shared/interfaces/clock.interface.ts
@@ -13,6 +13,7 @@ interface ClockInterface extends TimeInterface {
     /**
      * The current time
      * @type {Date}
+     * @deprecated The current time property is deprecated
      */
     currentTime: Date;
     /**

--- a/test/fixtures/todomvc-ng2/src/app/shared/interfaces/interfaces.ts
+++ b/test/fixtures/todomvc-ng2/src/app/shared/interfaces/interfaces.ts
@@ -4,6 +4,7 @@ import { ClockInterface } from './clock.interface';
 
 /**
  * An interface just for documentation purpose
+ * @deprecated This interface is deprecated
  */
 interface LabelledTodo {
     title: string;

--- a/test/fixtures/todomvc-ng2/src/app/shared/pipes/first-upper.pipe.ts
+++ b/test/fixtures/todomvc-ng2/src/app/shared/pipes/first-upper.pipe.ts
@@ -12,6 +12,7 @@ const pure = true;
  * @example
  *   {{ car |  firstUpper}}
  *   formats to: Car
+ * @deprecated This pipe is deprecated
  */
 @Pipe({
     name,
@@ -63,6 +64,7 @@ export class FirstUpperPipe implements PipeTransform {
 
     /**
      * the transform function
+     * @deprecated the transform function is deprecated
      * @param  {string} value the value of the pipe
      */
     transform(value: string): string {

--- a/test/fixtures/todomvc-ng2/src/app/shared/services/todo.store.ts
+++ b/test/fixtures/todomvc-ng2/src/app/shared/services/todo.store.ts
@@ -5,6 +5,7 @@ import { Todo } from '../models/todo.model';
 /**
  * This service is a todo store
  * See {@link Todo} for details about the main data of this store
+ * @deprecated This service is deprecated
  */
 @Injectable()
 export class TodoStore {
@@ -166,6 +167,7 @@ export class TodoStore {
 
     /**
      * Getter of _fullName
+     * @deprecated This getter is deprecated
      * @return {string} _fullName value
      */
     get fullName(): string {
@@ -174,6 +176,7 @@ export class TodoStore {
 
     /**
      * Setter of _fullName
+     * @deprecated This setter is deprecated
      * @param  {string} newName The new name
      */
     set fullName(newName: string) {

--- a/test/src/cli/cli-export.spec.ts
+++ b/test/src/cli/cli-export.spec.ts
@@ -79,6 +79,40 @@ describe('CLI Export', () => {
             expect(file).to.contain('"description": "<p>Getter of _fullName</p>\\n"');
         });
 
+        it('should display deprecated and deprecation messages', () => {
+            const file = read(`${distFolder}/documentation.json`, 'utf8');
+
+            expect(file).to.contain('"deprecated": true');
+            expect(file).to.contain('"deprecated": false');
+
+            // property
+            expect(file).to.contain('"deprecationMessage": "The current time property is deprecated"');
+
+            // method
+            expect(file).to.contain('"deprecationMessage": "the transform function is deprecated"');
+
+            // pipe
+            expect(file).to.contain(
+                '"deprecationMessage": "This pipe is deprecated"'
+            );
+
+            // interface
+            expect(file).to.contain(
+                '"deprecationMessage": "This interface is deprecated"'
+            );
+
+            // service
+            expect(file).to.contain(
+                '"deprecationMessage": "This service is deprecated"'
+            );
+
+            // accessor (setter)
+            expect(file).to.contain('"deprecationMessage": "This setter is deprecated"');
+
+            // accessor (getter)
+            expect(file).to.contain('"deprecationMessage": "This getter is deprecated"');
+        });
+
         it('should create json file', () => {
             let isFileExists = exists(`${distFolder}/documentation.json`);
             expect(isFileExists).to.be.true;


### PR DESCRIPTION
partly closes #937
Parses the @deprecated jsdoc tag so it can at least be used with the JSON output file, which is required by our team.
Can now more easily be further implemented so it is also displayed.