### PR TITLE
fix(app): merge overridden with inherited class members so they are not duplicated in the generated docs

### DIFF
--- a/src/utils/extends-merger.util.ts
+++ b/src/utils/extends-merger.util.ts
@@ -33,17 +33,14 @@ export class ExtendsMerger {
                             let newMethods = cloneDeep(cls.methods);
                             newMethods = this.markInheritance(newMethods, cls);
                             if (typeof component.methodsClass !== 'undefined') {
-                                component.methodsClass = [...component.methodsClass, ...newMethods];
+                                this.mergeInheritance(component, 'methodsClass', newMethods);
                             }
                         }
                         if (typeof cls.properties !== 'undefined' && cls.properties.length > 0) {
                             let newProperties = cloneDeep(cls.properties);
                             newProperties = this.markInheritance(newProperties, cls);
                             if (typeof component.propertiesClass !== 'undefined') {
-                                component.propertiesClass = [
-                                    ...component.propertiesClass,
-                                    ...newProperties
-                                ];
+                                this.mergeInheritance(component, 'propertiesClass', newProperties);
                             }
                         }
                         // From component to component
@@ -51,7 +48,7 @@ export class ExtendsMerger {
                             let newInputs = cloneDeep(cls.inputsClass);
                             newInputs = this.markInheritance(newInputs, cls);
                             if (typeof component.inputsClass !== 'undefined') {
-                                component.inputsClass = [...component.inputsClass, ...newInputs];
+                                this.mergeInheritance(component, 'inputsClass', newInputs);
                             }
                         }
                         if (
@@ -61,7 +58,7 @@ export class ExtendsMerger {
                             let newOutputs = cloneDeep(cls.outputsClass);
                             newOutputs = this.markInheritance(newOutputs, cls);
                             if (typeof component.outputsClass !== 'undefined') {
-                                component.outputsClass = [...component.outputsClass, ...newOutputs];
+                                this.mergeInheritance(component, 'outputsClass', newOutputs);
                             }
                         }
                         if (
@@ -71,7 +68,7 @@ export class ExtendsMerger {
                             let newMethods = cloneDeep(cls.methodsClass);
                             newMethods = this.markInheritance(newMethods, cls);
                             if (typeof component.methodsClass !== 'undefined') {
-                                component.methodsClass = [...component.methodsClass, ...newMethods];
+                                this.mergeInheritance(component, 'methodsClass', newMethods);
                             }
                         }
                         if (
@@ -81,10 +78,7 @@ export class ExtendsMerger {
                             let newProperties = cloneDeep(cls.propertiesClass);
                             newProperties = this.markInheritance(newProperties, cls);
                             if (typeof component.propertiesClass !== 'undefined') {
-                                component.propertiesClass = [
-                                    ...component.propertiesClass,
-                                    ...newProperties
-                                ];
+                                this.mergeInheritance(component, 'propertiesClass', newProperties);
                             }
                         }
                         if (
@@ -94,10 +88,7 @@ export class ExtendsMerger {
                             let newHostBindings = cloneDeep(cls.hostBindings);
                             newHostBindings = this.markInheritance(newHostBindings, cls);
                             if (typeof component.hostBindings !== 'undefined') {
-                                component.hostBindings = [
-                                    ...component.hostBindings,
-                                    ...newHostBindings
-                                ];
+                                this.mergeInheritance(component, 'hostBindings', newHostBindings);
                             }
                         }
                         if (
@@ -107,10 +98,7 @@ export class ExtendsMerger {
                             let newHostListeners = cloneDeep(cls.hostListeners);
                             newHostListeners = this.markInheritance(newHostListeners, cls);
                             if (typeof component.hostListeners !== 'undefined') {
-                                component.hostListeners = [
-                                    ...component.hostListeners,
-                                    ...newHostListeners
-                                ];
+                                this.mergeInheritance(component, 'hostListeners', newHostListeners);
                             }
                         }
                         if (Configuration.mainData.disableLifeCycleHooks) {
@@ -138,14 +126,14 @@ export class ExtendsMerger {
                             let newMethods = cloneDeep(cls.methods);
                             newMethods = this.markInheritance(newMethods, cls);
                             if (typeof el.methods !== 'undefined') {
-                                el.methods = [...el.methods, ...newMethods];
+                                this.mergeInheritance(el, 'methods', newMethods);
                             }
                         }
                         if (typeof cls.properties !== 'undefined' && cls.properties.length > 0) {
                             let newProperties = cloneDeep(cls.properties);
                             newProperties = this.markInheritance(newProperties, cls);
                             if (typeof el.properties !== 'undefined') {
-                                el.properties = [...el.properties, ...newProperties];
+                                this.mergeInheritance(el, 'properties', newProperties);
                             }
                         }
                         if (cls.extends) {
@@ -171,6 +159,20 @@ export class ExtendsMerger {
                 file: originalource.name
             };
             return newElement;
+        });
+    }
+
+    private mergeInheritance(component: any, metaPropertyId: string, newMembers: any) {
+        newMembers.forEach(newMember => {
+            const overriddenMethod = component[metaPropertyId].find(
+                componentMember => componentMember.name === newMember.name
+            );
+
+            if (overriddenMethod) {
+                overriddenMethod.inheritance = newMember.inheritance;
+            } else {
+                component[metaPropertyId].push(newMember);
+            }
         });
     }
 


### PR DESCRIPTION
Hi, in this pull request I'm trying to solve a problem that I described on #1034 

Today, the inherited class members are straightforward appended to the child class. In the new code, I'm just checking if the class members are also defined in the child class, and if they are, I just copy the `inheritance` metadata object into the child class member.