### PR TITLE
fix: Normalize path from generated additional docs. Replaces accented…

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,7 +20,7 @@ export function getNewLine(): string {
 }
 
 export function cleanNameWithoutSpaceAndToLowerCase(name: string): string {
-    return name.toLowerCase().replace(/ /g, '-');
+    return name.toLowerCase().replace(/ /g, '-').normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 }
 
 export function getCanonicalFileName(fileName: string): string {


### PR DESCRIPTION
… characters with its original relatives.

```json
{
    "title": "Instalação",
    "file": "installation.md"
},
```
Before:

![image](https://user-images.githubusercontent.com/1134016/112760343-fadfbf80-8fcc-11eb-8fcd-f8dd653de35c.png)

After:

![image](https://user-images.githubusercontent.com/1134016/112760397-324e6c00-8fcd-11eb-80f1-b617d7051025.png)
