### PR TITLE
fix: show custom logo even when in dark mode

### DIFF
--- a/src/templates/partials/menu.hbs
+++ b/src/templates/partials/menu.hbs
@@ -17,7 +17,7 @@ customElements.define('compodoc-menu', class extends HTMLElement {
                 <li class="title">
                     {{#if customLogo}}
                     <a href="index.html" data-type="index-link">
-                        <img alt="" class="img-responsive" data-type="compodoc-logo" data-src={{strip-url "images/" customLogo}}> 
+                        <img alt="" class="img-responsive" data-type="custom-logo" src={{strip-url "images/" customLogo}}>
                     </a>
                     {{else}}
                     <a href="index.html" data-type="index-link">{{documentationMainName}}</a>


### PR DESCRIPTION
I noticed that compodoc does not display the configured `customLogo` when the OS/browser is in dark mode. This PR fixes this issue.

I could not find any reason why the custom logo received the `data-type="compodoc-logo"` so I changed it to `custom-logo` and changed the `data-src` to `src`. The `data-type` as well as `data-src` seemed to only be used to determine whether to show the inverted logo. This is not necessary for the custom logo since we can assume users want their logo to be shown everywhere.

In the future we might want to add a `customDarkLogo` option to allow users to specify their own inverted logo.

## How to review
- generate a compodoc documentation using a custom logo and switch your Operating system to "dark mode"
- reload the documentation to see that the custom logo is still shown