### PR TITLE
fix(app): change layout in modules template

### DIFF
--- a/src/resources/styles/compodoc.css
+++ b/src/resources/styles/compodoc.css
@@ -132,7 +132,8 @@ a[href] {
 }
 
 .container-fluid.modules {
-    overflow-y: scroll;
+    width: 100%;
+    overflow-y: auto;
 }
 
 .container-fluid.module {

--- a/src/templates/partials/modules.hbs
+++ b/src/templates/partials/modules.hbs
@@ -4,7 +4,7 @@
 <div class="container-fluid modules">
     <div class="row">
         {{#each modules}}
-            <div class="col-sm-4">
+            <div class="col-md-6 col-lg-4">
                 <div class="card card-module">
                     <div class="card-header">
                         <h4 class="card-title">{{name}}</h4>


### PR DESCRIPTION
This PR fixes the layout in the modules page:

1. Removes scroll when it's not needed
2. Sets the container to 100%, so if <3 elements, they don't shrink
3. Improves responsiveness

https://user-images.githubusercontent.com/22116465/137595589-bac84f58-0641-46a8-829e-54059f4bc0d3.mp4

https://user-images.githubusercontent.com/22116465/137595588-4e2b6f70-4171-4468-b758-7fcf0fc8f62a.mp4


