### PR TITLE
feat: add decorators to class inputs

### DIFF
--- a/src/app/compiler/angular/deps/helpers/class-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/class-helper.ts
@@ -1481,6 +1481,11 @@ export class ClassHelper {
                 }
             }
         }
+        if (property.decorators) {
+            _return.decorators = this.formatDecorators(property.decorators).filter(
+                item => item.name !== 'Input' && item.name !== 'HostBinding'
+            );
+        }
         return _return;
     }
 

--- a/test/fixtures/todomvc-ng2/src/app/about/about.component.ts
+++ b/test/fixtures/todomvc-ng2/src/app/about/about.component.ts
@@ -40,6 +40,12 @@ export class AboutComponent {
      */
     @Input() public angularVersion = 'Angular 2';
 
+    /**
+     * Dummy input property with a custom decorator
+     */
+    @MyCustomInputDecorator()
+    @Input() public myInput: string;
+
     chartOptions: Highcharts.Options = {
         colors: [
             '#7cb5ec',

--- a/test/src/cli/cli-export.spec.ts
+++ b/test/src/cli/cli-export.spec.ts
@@ -139,6 +139,15 @@ describe('CLI Export', () => {
             expect(file).to.contain('coveragePercent');
         });
 
+        it('should export custom input decorators for components', () => {
+            const file = read(`${distFolder}/documentation.json`);
+            const obj = JSON.parse(file);
+            const component = obj.components.find(comp => comp.name === 'AboutComponent');
+            const input = component.inputsClass.find(inp => inp.name === 'myInput');
+
+            expect(input.decorators.find(dec => dec.name === 'MyCustomInputDecorator')).to.be.ok;
+        });
+
         it('should get jsdoctags in component', () => {
             const file = read(`${distFolder}/documentation.json`);
 


### PR DESCRIPTION
Since `@Input` is not always the only one decorator for input properties.
Mainly used for custom input decorators.