### PR TITLE
fix(link-parser): avoid crashing with invalid links

### DIFF
--- a/src/utils/jsdoc-parser.util.ts
+++ b/src/utils/jsdoc-parser.util.ts
@@ -271,8 +271,11 @@ export class JsdocParserUtil {
                             break;
                         case SyntaxKind.JSDocLink:
                             if (JSDocNode.name) {
-                                rawDescription +=
-                                    JSDocNode.text + '{@link ' + JSDocNode.name.escapedText + '}';
+                                let text = JSDocNode.name.escapedText;
+                                if (text === undefined && JSDocNode.name.left && JSDocNode.name.right) {
+                                    text = JSDocNode.name.left.escapedText + '.' + JSDocNode.name.right.escapedText;
+                                }
+                                rawDescription += JSDocNode.text + '{@link ' + text + '}';
                             }
                             break;
                         default:

--- a/src/utils/link-parser.ts
+++ b/src/utils/link-parser.ts
@@ -64,6 +64,9 @@ export let LinkParser = (function() {
             stringtoReplace = tagInfo.completeTag;
             linkText = split.linkText;
         }
+        if (linkText === '' || linkText == null || target == null) {
+            return string;
+        }
 
         return string.replace(stringtoReplace, '[' + linkText + '](' + target + ')');
     };

--- a/test/fixtures/todomvc-ng2/src/app/about/about.component.ts
+++ b/test/fixtures/todomvc-ng2/src/app/about/about.component.ts
@@ -99,9 +99,17 @@ export class AboutComponent {
         return '';
     }
 
+     /**
+      * This is for testing
+      * @returns '', if this {@link AboutComponent.fullName} does not crash
+      */
     public publicMethod(): string {
         return '';
     }
 
+     /**
+      * This is for testing
+      * @returns a promise, if this {@link undefined} does not crash
+      */
     public async foo(): Promise<any> {}
 }

--- a/test/src/cli/cli-generation-big-app.spec.ts
+++ b/test/src/cli/cli-generation-big-app.spec.ts
@@ -876,6 +876,12 @@ describe('CLI simple generation - big app', () => {
         expect(file).to.contain('_fullName <a href="https://compodoc.app/">https://compodoc.app/');
     });
 
+    it('should not crash with invalid JSDoc @link tags', () => {
+        let file = read(distFolder + '/components/AboutComponent.html');
+        expect(file).to.contain('if this {@link AboutComponent.fullName} does not crash');
+        expect(file).to.contain('if this {@link undefined} does not crash');
+    });
+
     it('should support multiple decorators for component for example', () => {
         let file = read(distFolder + '/components/AboutComponent.html');
         expect(file).to.contain('<code>src/app/about/about.component.ts</code>');


### PR DESCRIPTION
As of version `1.1.14`, generating our documentation crashes and throws the following error:

~~~
Unhandled Rejection at: Promise {
  <rejected> RangeError: Maximum call stack size exceeded
      at RegExp.exec (<anonymous>)
      at replaceLinkTag (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:527:33)
      at Object._resolveLinks [as resolveLinks] (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:543:16)
      at /Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:903:43
      at arrayEach (/Users/sandra/dev/siemens/simpl-element/node_modules/lodash/lodash.js:530:11)
      at Object.forEach (/Users/sandra/dev/siemens/simpl-element/node_modules/lodash/lodash.js:9410:14)
      at markedtags (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:901:18)
      at ClassHelper.addAccessor (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:6809:46)
      at ClassHelper.visitMembers (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:7228:38)
      at ClassHelper.visitClassDeclaration (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:7020:24)
} reason: RangeError: Maximum call stack size exceeded
    at RegExp.exec (<anonymous>)
    at replaceLinkTag (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:527:33)
    at Object._resolveLinks [as resolveLinks] (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:543:16)
    at /Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:903:43
    at arrayEach (/Users/sandra/dev/siemens/simpl-element/node_modules/lodash/lodash.js:530:11)
    at Object.forEach (/Users/sandra/dev/siemens/simpl-element/node_modules/lodash/lodash.js:9410:14)
    at markedtags (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:901:18)
    at ClassHelper.addAccessor (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:6809:46)
    at ClassHelper.visitMembers (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:7228:38)
    at ClassHelper.visitClassDeclaration (/Users/sandra/dev/siemens/simpl-element/node_modules/@compodoc/compodoc/dist/index-cli-8ef9c2ed.js:7020:24)
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
~~~

The problem is that when a link is unresolved, the `LinkParser` tries to replace the string and then forms a new string, which in turn is matched for the regular expression and then repeated over and over again. This results in something like the following:

~~~
string: `true`, if {@link undefined} is true and
the form is valid.

string: `true`, if {@link []([]([](undefined)))} is true and
the form is valid.

string: `true`, if {@link []([]([]([]([]([]([](undefined)))))))} is true and
the form is valid.

...

string: `true`, if {@link []([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([]([](undefined)))))))))))))))))))))))))))))))} is true and
the form is valid.

...
~~~

Apparently since version `1.1.14` the input data for resolving the links are different.

This PR simply ensures that for unresolved links the execution does not abort, but returns the unresolved links 1:1.