### PR TITLE
feat: fully parse set accessor type

### DIFF
--- a/src/app/compiler/angular/deps/helpers/class-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/class-helper.ts
@@ -1488,7 +1488,7 @@ export class ClassHelper {
             // For setter accessor, find type in first parameter
             if (property.parameters && property.parameters.length === 1) {
                 if (property.parameters[0].type) {
-                    _return.type = kindToType(property.parameters[0].type.kind);
+                    _return.type = this.visitType(property.parameters[0].type);
                 }
             }
         }


### PR DESCRIPTION
Currently only the `kind` of a set accessor is parsed. I  see no reason not to also parse the full type in the same way it is parsed normally.