### PR TITLE
Add support for Object Expression as a valid input for the Input decorator

### DIFF
--- a/src/app/compiler/angular/deps/helpers/class-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/class-helper.ts
@@ -1445,12 +1445,32 @@ export class ClassHelper {
     private visitInputAndHostBinding(property, inDecorator, sourceFile?) {
         let inArgs = inDecorator.expression.arguments;
         let _return: any = {};
-        _return.name = inArgs.length > 0 ? inArgs[0].text : property.name.text;
+
+        let getRequiredField = () =>
+            inArgs[0].properties.find(property => property.name.escapedText === 'required');
+        let getAliasProperty = () =>
+            inArgs[0].properties.find(property => property.name.escapedText === 'alias');
+
+        let isInputConfigStringLiteral = inArgs[0] && ts.isStringLiteral(inArgs[0]);
+        let isInputConfigObjectLiteralExpression = inArgs[0] && ts.isObjectLiteralExpression(inArgs[0]);
+        let hasRequiredField = isInputConfigObjectLiteralExpression && !!getRequiredField();
+        let hasAlias = isInputConfigObjectLiteralExpression ? !!getAliasProperty() : false;
+
+        _return.name = isInputConfigStringLiteral
+            ? inArgs[0].text
+            : hasAlias
+            ? getAliasProperty().initializer.text
+            : property.name.text;
         _return.defaultValue = property.initializer
             ? this.stringifyDefaultValue(property.initializer)
             : undefined;
         _return.deprecated = false;
         _return.deprecationMessage = '';
+
+        if (hasRequiredField) {
+            _return.optional = getRequiredField().initializer.kind !== SyntaxKind.TrueKeyword;
+        }
+        
         if (!_return.description) {
             if (property.jsDoc) {
                 if (property.jsDoc.length > 0) {

--- a/test/fixtures/sample-files/foo.component.ts
+++ b/test/fixtures/sample-files/foo.component.ts
@@ -32,6 +32,26 @@ export class FooComponent {
     @Input() exampleInput: string = 'foo';
 
     /**
+     * An example required input
+     */
+    @Input({ required: true }) requiredInput: string;
+
+    /**
+     * An example aliased input
+     */
+    @Input('aliasedInput') aliasedInput: string;
+
+    /**
+     * An example aliased input using the object syntax
+     */
+    @Input({ alias: 'aliasedInput' }) objectAliasedInput: string;
+
+    /**
+     * An example aliased required input using the object syntax
+     */
+    @Input({ alias: 'aliasedInput' }) aliasedAndRequired: string;
+
+    /**
      * An example output
      */
     @Output() exampleOutput: EventEmitter<{ foo: string }> = new EventEmitter();


### PR DESCRIPTION
In Angular 16, you can pass an object expression as an argument for the Input decorator.

This PR adds support for the following cases:

```tsx
@Input({ required: <true|false> })
requiredInput: any;

@Input({ alias: 'some-alias' })
aliasedInput: any;

@Input({ required: <true|false>, alias: 'some-alias' })
requiredAndAliased: any;
```

**Additional information:**
Hi! I am a **Storybook** maintainer, and currently, we evaluate Angular 16 support in Storybook, which will be released in the first week of May. Now, Storybook relies heavily on Compodoc to extract type information. Passing an object expression to the Input decorator currently breaks completely because compodoc a) wrongly extracts the `name` property of the input (it always assumes that a `StringLiteral` is passed in as the only valid argument) and b) cannot handle object expressions as valid decorator arguments.

**Further help needed:**
I need help writing a unit test for the mentioned cases. I need some assistance to place a unit test into the right place.

**PR opened against `master` instead of `develop`
I don't know how stable develop is and whether a soon-ish release of develop might be possible. Therefore, I've created the PR against `master`, hoping, that this fix might be released as a hotfix release.