### PR TITLE
feat(app): display inputsignals as inputs rather than properties

### DIFF
--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -248,8 +248,12 @@ export class AngularDependencies extends FrameworkDependencies {
         if (IO.constructor && !Configuration.mainData.disableConstructors) {
             deps.constructorObj = IO.constructor;
         }
+       if (IO.inputs) {
+            deps.inputsClass = IO.inputs;
+        }
         if (IO.properties) {
             deps.properties = IO.properties;
+            deps.inputsClass = deps.inputsClass ? deps.inputsClass.concat(this.componentHelper.getInputSignals(IO.properties)) : this.componentHelper.getInputSignals(IO.properties);
         }
         if (IO.description) {
             deps.description = IO.description;
@@ -271,9 +275,6 @@ export class AngularDependencies extends FrameworkDependencies {
         }
         if (IO.accessors) {
             deps.accessors = IO.accessors;
-        }
-        if (IO.inputs || IO.properties) {
-            deps.inputsClass = this.componentHelper.getInputSignals(IO.properties).concat(IO.inputs);
         }
         if (IO.outputs) {
             deps.outputsClass = IO.outputs;

--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -272,8 +272,8 @@ export class AngularDependencies extends FrameworkDependencies {
         if (IO.accessors) {
             deps.accessors = IO.accessors;
         }
-        if (IO.inputs) {
-            deps.inputsClass = IO.inputs;
+        if (IO.inputs || IO.properties) {
+            deps.inputsClass = this.componentHelper.getInputSignals(IO.properties).concat(IO.inputs);
         }
         if (IO.outputs) {
             deps.outputsClass = IO.outputs;

--- a/src/app/compiler/angular/deps/component-dep.factory.ts
+++ b/src/app/compiler/angular/deps/component-dep.factory.ts
@@ -88,6 +88,9 @@ export class ComponentDepFactory {
         if (IO.accessors) {
             componentDep.accessors = IO.accessors;
         }
+        if (IO.properties) {
+            componentDep.inputsClass = componentDep.inputsClass.concat(this.helper.getInputSignals(IO.properties));
+        }
 
         return componentDep;
     }

--- a/src/app/compiler/angular/deps/directive-dep.factory.ts
+++ b/src/app/compiler/angular/deps/directive-dep.factory.ts
@@ -26,7 +26,7 @@ export class DirectiveDepFactory {
 
             standalone: this.helper.getComponentStandalone(props, srcFile) ? true : false,
 
-            inputsClass: IO.inputs,
+            inputsClass: this.helper.getInputSignals(IO.properties).concat(IO.inputs),
             outputsClass: IO.outputs,
 
             deprecated: IO.deprecated,

--- a/src/app/compiler/angular/deps/helpers/component-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/component-helper.ts
@@ -135,6 +135,21 @@ export class ComponentHelper {
         return this.symbolHelper.getSymbolDeps(props, 'inputs', srcFile);
     }
 
+    public getInputSignals(props) {
+        let inputSignals = [];
+        props?.forEach((prop, i) => {
+            const regexp = /input(?:\.(required))?(?:<([\w-]+)>)?\(([\w-]+)?\)/;
+            const res = regexp.exec(prop.defaultValue);
+            if (res) {
+                const newInput = prop;
+                newInput.defaultValue = res[res.length - 1];
+                newInput.required = res[0]?.includes('.required') ?? false;
+                inputSignals.push(newInput);
+            }
+        });
+        return inputSignals;
+    }
+
     public getComponentStandalone(
         props: ReadonlyArray<ts.ObjectLiteralElementLike>,
         srcFile: ts.SourceFile


### PR DESCRIPTION
Closes #1434.

I didn't find a better way to extract the input signals than with a regex inside the properties
