### PR TITLE
fix(app): remove trailing commas from routes

### DIFF
--- a/test/fixtures/todomvc-ng2-simple-routing-standard/src/app/app-routing.module.ts
+++ b/test/fixtures/todomvc-ng2-simple-routing-standard/src/app/app-routing.module.ts
@@ -6,7 +6,9 @@ export const APP_ROUTES: Routes = [
     {
         path: 'about',
         loadChildren: (): Promise<AboutModule> =>
-            import('./about/about.module').then(m => m.AboutModule)
+            // Trailing comma is added intentionally to test
+            // module parsing specifically for this case.
+            import('./about/about.module').then(m => m.AboutModule,)
     },
     { path: '', redirectTo: 'home', pathMatch: 'full' },
     { path: '**', redirectTo: 'home', pathMatch: 'full' }

--- a/test/src/cli/cli-routes-graph.spec.ts
+++ b/test/src/cli/cli-routes-graph.spec.ts
@@ -83,7 +83,7 @@ describe('CLI Routes graph', () => {
         });
     });
 
-    describe('should support lazy loading modules with new loadChildren syntax', () => {
+    describe('should support lazy-loaded modules with loadChildren syntax (containing possible trailing commas)', () => {
         before(function (done) {
             tmp.create(distFolder);
             const ls = shell('node', [
@@ -110,7 +110,7 @@ describe('CLI Routes graph', () => {
         });
     });
 
-    describe('should support lazy loading modules with new loadChildren syntax / async', () => {
+    describe('should support lazy-loaded modules with new loadChildren syntax / async', () => {
         before(function (done) {
             tmp.create(distFolder);
             const ls = shell('node', [


### PR DESCRIPTION
Fixes `"Routes parsing error, maybe a trailing comma or an external variable, trying to fix that later after sources scanning."` error when that error occurs due to trailing commas (by removing trailing commas for [all possible cases](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#description)) + a bit of refactoring