### PR TITLE
fix: fix detection of signals default value and type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,13 @@
     "packages": {
         "": {
             "name": "@compodoc/compodoc",
-            "version": "1.1.24",
+            "version": "1.1.25",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "@angular-devkit/schematics": "18.0.1",
                 "@babel/core": "^7.24.6",
+                "@babel/parser": "^7.24.6",
                 "@babel/plugin-transform-private-methods": "^7.24.6",
                 "@babel/preset-env": "^7.24.6",
                 "@compodoc/live-server": "^1.2.3",
@@ -645,6 +646,7 @@
             "version": "7.24.6",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.6.tgz",
             "integrity": "sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==",
+            "license": "MIT",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "dependencies": {
         "@angular-devkit/schematics": "18.0.1",
         "@babel/core": "^7.24.6",
+        "@babel/parser": "^7.24.6",
         "@babel/plugin-transform-private-methods": "^7.24.6",
         "@babel/preset-env": "^7.24.6",
         "@compodoc/live-server": "^1.2.3",

--- a/src/app/compiler/angular/deps/helpers/component-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/component-helper.ts
@@ -143,7 +143,7 @@ export class ComponentHelper {
             const ast = parseExpression(expression, {
                 plugins: ['typescript']
             });
-            const methodName: string = ast?.callee?.name;
+            const methodName: string = ast?.callee?.name ?? ast?.callee?.object?.name;
             if (methodName !== 'input' && methodName !== 'model') {
                 return;
             }

--- a/src/app/compiler/angular/deps/helpers/component-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/component-helper.ts
@@ -1,5 +1,6 @@
+import { parseExpression } from '@babel/parser';
 import { SyntaxKind, ts } from 'ts-morph';
-import { detectIndent } from '../../../../../utils';
+import { detectIndent, getSubstringFromMultilineString } from '../../../../../utils';
 import { ClassHelper } from './class-helper';
 import { IParseDeepIdentifierResult, SymbolHelper } from './symbol-helper';
 
@@ -138,23 +139,27 @@ export class ComponentHelper {
     public getInputSignals(props) {
         let inputSignals = [];
         props?.forEach((prop, i) => {
-            const regexpInput = /input(?:\.(required))?(?:<([\w-]+)>)?\(([\w-]+)?\)/;
-            const resInput = regexpInput.exec(prop.defaultValue);
-            if (resInput) {
-                const newInput = prop;
-                newInput.defaultValue = resInput[resInput.length - 1];
-                newInput.required = resInput[0]?.includes('.required') ?? false;
-                inputSignals.push(newInput);
-            } else {
-                const regexpModel = /model(?:\.(required))?(?:<([\w-]+)>)?\(([\w-]+)?\)/;
-                const resModel = regexpModel.exec(prop.defaultValue);
-                if (resModel) {
-                    const newInput = prop;
-                    newInput.defaultValue = resModel[resModel.length - 1];
-                    newInput.required = resModel[0]?.includes('.required') ?? false;
-                    inputSignals.push(newInput);
-                }
+            const expression = prop.defaultValue;
+            const ast = parseExpression(expression, {
+                plugins: ['typescript']
+            });
+            const methodName: string = ast?.callee?.name;
+            if (methodName !== 'input' && methodName !== 'model') {
+                return;
             }
+            const newInput = prop;
+            newInput.defaultValue = ast?.arguments[0]?.value;
+            newInput.required = ast?.callee?.property?.name === 'required';
+            const inputTypeParams = ast?.typeParameters ?? ast?.callee?.typeParameters;
+            if (inputTypeParams?.type === 'TSTypeParameterInstantiation') {
+                const start = inputTypeParams?.loc?.start;
+                const end = inputTypeParams?.loc?.end;
+                newInput.type = getSubstringFromMultilineString(expression, start?.line, start?.column, end?.line, end?.column);
+            } else {
+                // Otherwise, use typeof to get the type from defaultValue
+                newInput.type = newInput.defaultValue === undefined ? undefined : typeof newInput.defaultValue;
+            }
+            inputSignals.push(newInput);
         });
         return inputSignals;
     }
@@ -305,6 +310,7 @@ export class ComponentHelper {
     ): Array<string> {
         return this.symbolHelper.getSymbolDeps(props, 'templateUrl', srcFile);
     }
+
     public getComponentExampleUrls(text: string): Array<string> | undefined {
         let exampleUrlsMatches = text.match(/<example-url>(.*?)<\/example-url>/g);
         let exampleUrls = undefined;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -11,6 +11,7 @@ import { AngularLifecycleHooks } from './angular-lifecycles-hooks';
 import { kindToType } from './kind-to-type';
 import { JsdocParserUtil } from './jsdoc-parser.util';
 import { markedAcl } from './marked.acl';
+import exp = require('node:constants');
 
 const getCurrentDirectory = ts.sys.getCurrentDirectory;
 const useCaseSensitiveFileNames = ts.sys.useCaseSensitiveFileNames;
@@ -387,6 +388,28 @@ export function detectIndent(str, count): string {
     };
 
     return indentString(stripIndent(str), count || 0);
+}
+
+export function getSubstringFromMultilineString(multilineString: string, startLine: number, startColumn: number, endLine: number, endColumn: number) {
+    // Split the string into lines
+    const lines = multilineString.split('\n');
+
+    // Slice the lines from startLine to endLine
+    const selectedLines = lines.slice(startLine - 1, endLine);
+
+    // If startLine and endLine are the same, slice the line from startColumn to endColumn
+    if (startLine === endLine) {
+        selectedLines[0] = selectedLines[0].slice(startColumn + 1, endColumn - 1);
+    } else {
+        // Otherwise, slice the start line from startColumn to the end
+        selectedLines[0] = selectedLines[0].slice(startColumn + 1);
+
+        // And slice the end line from the start to endColumn
+        selectedLines[selectedLines.length - 1] = selectedLines[selectedLines.length - 1].slice(0, endColumn - 1);
+    }
+
+    // Join the lines back together into a single string
+    return selectedLines.join('\n');
 }
 
 export const INCLUDE_PATTERNS = ['**/*.ts', '**/*.tsx'];


### PR DESCRIPTION
Closes #1490 
Closes #1489 

Used a `@babel/parse` instead of the regex to better detect defaultValue and type of the `input` or `model`.

I believe this approach can also be used to fix #1481 as the output detection relies on the same regex. 