### PR TITLE
refactor: migrate `chalk` to  `picocolors`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,19 +1,12 @@
 {
-    "extends": [
-        "config:base"
-    ],
-    "ignoreDeps": [
-        "os-name",
-        "pdfjs-dist"
-    ],
+    "extends": ["config:base"],
+    "ignoreDeps": ["os-name", "pdfjs-dist"],
     "groupName": "all dependencies",
     "separateMajorMinor": false,
     "groupSlug": "all",
     "packageRules": [
         {
-            "matchPackagePatterns": [
-                "*"
-            ],
+            "matchPackagePatterns": ["*"],
             "groupName": "all dependencies",
             "groupSlug": "all"
         }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,19 @@
 {
-    "extends": ["config:base"],
-    "ignoreDeps": ["chalk", "os-name", "pdfjs-dist"],
+    "extends": [
+        "config:base"
+    ],
+    "ignoreDeps": [
+        "os-name",
+        "pdfjs-dist"
+    ],
     "groupName": "all dependencies",
     "separateMajorMinor": false,
     "groupSlug": "all",
     "packageRules": [
         {
-            "matchPackagePatterns": ["*"],
+            "matchPackagePatterns": [
+                "*"
+            ],
             "groupName": "all dependencies",
             "groupSlug": "all"
         }

--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,4 +1,10 @@
 {
     "upgrade": true,
-    "reject": ["os-name", "chalk", "pdfjs-dist", "marked", "chai", "eslint"]
+    "reject": [
+        "os-name",
+        "pdfjs-dist",
+        "marked",
+        "chai",
+        "eslint"
+    ]
 }

--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,10 +1,4 @@
 {
     "upgrade": true,
-    "reject": [
-        "os-name",
-        "pdfjs-dist",
-        "marked",
-        "chai",
-        "eslint"
-    ]
+    "reject": ["os-name", "pdfjs-dist", "marked", "chai", "eslint"]
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,9 +1,3 @@
 {
-    "ignoreDeps": [
-        "os-name",
-        "pdfjs-dist",
-        "marked",
-        "chai",
-        "eslint"
-    ]
+    "ignoreDeps": ["os-name", "pdfjs-dist", "marked", "chai", "eslint"]
 }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,3 +1,9 @@
 {
-    "ignoreDeps": ["os-name", "chalk", "pdfjs-dist", "marked", "chai", "eslint"]
+    "ignoreDeps": [
+        "os-name",
+        "pdfjs-dist",
+        "marked",
+        "chai",
+        "eslint"
+    ]
 }

--- a/DONTUPDATE.md
+++ b/DONTUPDATE.md
@@ -2,6 +2,5 @@
 
 marked - version 5.0.0 requires Node.js v18 which is too agressive
 os-name - version 5.0.0 use ESM modules
-chalk - version 5.0.0 use ESM modules
 pdfjs-dist - version 4.0.379 until PromiseWithResolvers + TS issue fixed
 eslint - issue with typescript-eslint

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "@compodoc/live-server": "^1.2.3",
                 "@compodoc/ngd-transformer": "^2.1.3",
                 "bootstrap.native": "^5.0.12",
-                "chalk": "4.1.2",
                 "cheerio": "^1.0.0-rc.12",
                 "chokidar": "^3.6.0",
                 "colors": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
         "@compodoc/live-server": "^1.2.3",
         "@compodoc/ngd-transformer": "^2.1.3",
         "bootstrap.native": "^5.0.12",
-        "chalk": "4.1.2",
         "cheerio": "^1.0.0-rc.12",
         "chokidar": "^3.6.0",
         "colors": "1.4.0",

--- a/src-refactored/infrastructure/logging/logger.ts
+++ b/src-refactored/infrastructure/logging/logger.ts
@@ -1,14 +1,14 @@
 const log = require('loglevel');
 
-const chalk = require('chalk');
+const pico = require('picocolors');
 const loglevelpluginPrefix = require('loglevel-plugin-prefix');
 
 const LEVEL = {
-    LOG: chalk.green,
-    DEBUG: chalk.cyan,
-    INFO: chalk.green,
-    WARN: chalk.yellow,
-    ERROR: chalk.red,
+    LOG: pico.green,
+    DEBUG: pico.cyan,
+    INFO: pico.green,
+    WARN: pico.yellow,
+    ERROR: pico.red,
 };
 
 export class Logger {
@@ -72,19 +72,19 @@ export class Logger {
         switch (level) {
             case LEVEL.INFO:
             case LEVEL.LOG:
-                msg = chalk.green(msg);
+                msg = pico.green(msg);
                 break;
 
             case LEVEL.DEBUG:
-                msg = chalk.cyan(msg);
+                msg = pico.cyan(msg);
                 break;
 
             case LEVEL.WARN:
-                msg = chalk.yellow(msg);
+                msg = pico.yellow(msg);
                 break;
 
             case LEVEL.ERROR:
-                msg = chalk.red(msg);
+                msg = pico.red(msg);
                 break;
         }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,5 @@
 let log = require('fancy-log');
-let c = require('chalk');
+let pico = require('picocolors');
 
 enum LEVEL {
     INFO,
@@ -54,19 +54,19 @@ class Logger {
 
         switch (level) {
             case LEVEL.INFO:
-                msg = c.green(msg);
+                msg = pico.green(msg);
                 break;
 
             case LEVEL.DEBUG:
-                msg = c.cyan(msg);
+                msg = pico.cyan(msg);
                 break;
 
             case LEVEL.WARN:
-                msg = c.yellow(msg);
+                msg = pico.yellow(msg);
                 break;
 
             case LEVEL.ERROR:
-                msg = c.red(msg);
+                msg = pico.red(msg);
                 break;
         }
 


### PR DESCRIPTION
## Changes

<!-- Describe what behavior is changed by this PR. -->
Removed `chalk` in favor of `picocolors`. https://github.com/alexeyraspopov/picocolors

## Context

As part of the ongoing [ecosystem cleanup](https://github.com/es-tooling/ecosystem-cleanup), we are migrating various projects to use lighter/faster packages.

In this case, moving from chalk to picocolors.

<img width="528" alt="image" src="https://github.com/user-attachments/assets/7e2a02c3-c406-49a4-a6d8-1e3ce5cce6d4">


- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work

`npm run test-refactoring`