### PR TITLE
fix: pin cheerio as it now dependens on a minimum version of Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "@compodoc/ngd-transformer": "^2.1.3",
         "bootstrap.native": "^5.0.12",
         "chalk": "4.1.2",
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "chokidar": "^3.6.0",
         "colors": "1.4.0",
         "commander": "^12.1.0",


### PR DESCRIPTION
Fixes #1504 