### PR TITLE
fix: angular signal input/output detection

### DIFF
--- a/src/app/compiler/angular/deps/helpers/component-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/component-helper.ts
@@ -166,7 +166,6 @@ export class ComponentHelper {
             const res = regexp.exec(prop.defaultValue);
             if (res) {
                 const newOutput = prop;
-                newOutput.defaultValue = null;
                 newOutput.required = false;
                 outputSignals.push(newOutput);
             }

--- a/src/app/compiler/angular/deps/helpers/component-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/component-helper.ts
@@ -138,7 +138,7 @@ export class ComponentHelper {
     public getInputSignals(props) {
         let inputSignals = [];
         props?.forEach((prop, i) => {
-            const regexpInput = /input(?:\.(required))?(?:<([\w-]+)>)?\(([\w-]+)?\)/;
+            const regexpInput = /input(?:\.(required))?(?:<([\w\s|[\]]+)>)?\(([^)]*)\)/;
             const resInput = regexpInput.exec(prop.defaultValue);
             if (resInput) {
                 const newInput = prop;
@@ -146,7 +146,7 @@ export class ComponentHelper {
                 newInput.required = resInput[0]?.includes('.required') ?? false;
                 inputSignals.push(newInput);
             } else {
-                const regexpModel = /model(?:\.(required))?(?:<([\w-]+)>)?\(([\w-]+)?\)/;
+                const regexpModel = /model(?:\.(required))?(?:<([\w\s|[\]]+)>)?\(([^)]*)\)/;
                 const resModel = regexpModel.exec(prop.defaultValue);
                 if (resModel) {
                     const newInput = prop;
@@ -162,12 +162,12 @@ export class ComponentHelper {
     public getOutputSignals(props) {
         let outputSignals = [];
         props?.forEach((prop, i) => {
-            const regexp = /output(?:\.(required))?(?:<([\w-]+)>)?\(([\w-]+)?\)/;
+            const regexp = /(output(?:FromObservable)?)(?:<([\w\s|[\]]+)>)?\(([^)]*?)(?:,\s*({[^}]*}))?\)/;
             const res = regexp.exec(prop.defaultValue);
             if (res) {
                 const newOutput = prop;
-                newOutput.defaultValue = res[res.length - 1];
-                newOutput.required = res[0]?.includes('.required') ?? false;
+                newOutput.defaultValue = null;
+                newOutput.required = false;
                 outputSignals.push(newOutput);
             }
         });


### PR DESCRIPTION
The current implementation of getting signal inputs/outputs is a little limited. There are quite a few use cases that it doesn't support.

Examples (same goes for model inputs):
```typescript
input<string | number | boolean>(); // multiple types
input<string>('pill'); // string values as parameter
input<BadgeOption>(BadgeOption.Default); // enum values
input<string>(this.config.color); // values from injected service/token
input<BadgeOption[]>([]); // arrays
```

So i changed the regex to be less strict:
```
/input(?:\.(required))?(?:<([\w\s|[\]]+)>)?\(([^)]*)\)/
```

ChatGpt explanation of the regex:
![image](https://github.com/user-attachments/assets/2e700383-2698-4615-b6d5-931eed7fcee9)


I also changed the output regex to:
```
/(output(?:FromObservable)?)(?:<([\w\s|[\]]+)>)?\(([^)]*?)(?:,\s*({[^}]*}))?\)/
```

![image](https://github.com/user-attachments/assets/134a2084-f3eb-4973-9d24-1f8d2cae1d32)


I also changed the code because outputs don't have a required property or default value. I also included the `outputFromObservable` option, not just the more used `output` option