### PR TITLE
fix(symbolHelper): properly parse provider config object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@compodoc/compodoc",
-            "version": "1.1.25",
+            "version": "1.1.26",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/src/utils/imports.util.ts
+++ b/src/utils/imports.util.ts
@@ -228,6 +228,7 @@ export class ImportsUtil {
                 decoratorType === 'template' &&
                 searchedImport.getModuleSpecifierValue().indexOf('.html') !== -1
             ) {
+                // @ts-ignore
                 const originalSourceFilePath = sourceFile.path;
                 const originalSourceFilePathFolder = originalSourceFilePath.substring(
                     0,

--- a/test/.mocharc.json
+++ b/test/.mocharc.json
@@ -3,6 +3,6 @@
     "extension": ["ts"],
     "ui": "bdd",
     "timeout": 120000,
-    "spec": "test/src/cli/*.spec.ts",
+    "spec": "test/src/**/*.spec.ts",
     "require": "ts-node/esm"
 }

--- a/test/src/app/compiler/angular/deps/helpers/symbol.helper.spec.ts
+++ b/test/src/app/compiler/angular/deps/helpers/symbol.helper.spec.ts
@@ -1,0 +1,68 @@
+import {expect} from 'chai';
+import {ts, Project, SourceFile} from 'ts-morph';
+
+import {SymbolHelper} from '../../../../../../../src/app/compiler/angular/deps/helpers/symbol-helper';
+
+describe(SymbolHelper.name, () => {
+    let helper: SymbolHelper;
+
+    const sourceFileName = 'SymbolHelper.test.ts';
+    let sourceFile: SourceFile;
+
+    const project = new Project();
+
+    beforeEach(() => {
+        helper = new SymbolHelper();
+    });
+
+    afterEach(() => {
+        sourceFile.delete();
+    })
+
+    describe('parseProviderConfiguration', () => {
+        it('should return identifier for basic provider config', () => {
+            sourceFile = project.createSourceFile(sourceFileName, `const provider = TestProvider;`);
+
+            const providerConfig = sourceFile.getVariableDeclaration("provider")!.getInitializer()!.compilerNode as ts.ObjectLiteralExpression;
+            const result = helper.parseProviderConfiguration(providerConfig);
+
+            expect(result).to.equal('TestProvider');
+        });
+
+        it('should return identifier for "useClass" provider config', () => {
+            sourceFile = project.createSourceFile(sourceFileName, `const provider = {provide: 'test', useClass: TestProvider};`);
+
+            const providerConfig = sourceFile.getVariableDeclaration("provider")!.getInitializer()!.compilerNode as ts.ObjectLiteralExpression;
+            const result = helper.parseProviderConfiguration(providerConfig);
+
+            expect(result).to.equal('TestProvider');
+        });
+
+        it('should return identifier for "useValue" provider config', () => {
+            sourceFile = project.createSourceFile(sourceFileName, `const provider = {provide: 'test', useValue: TestProvider};`);
+
+            const providerConfig = sourceFile.getVariableDeclaration("provider")!.getInitializer()!.compilerNode as ts.ObjectLiteralExpression;
+            const result = helper.parseProviderConfiguration(providerConfig);
+
+            expect(result).to.equal('TestProvider');
+        });
+
+        it('should return identifier for "useFactory" provider config', () => {
+            sourceFile = project.createSourceFile(sourceFileName, `const provider = {provide: 'test', useFactory: () => TestProvider};`);
+
+            const providerConfig = sourceFile.getVariableDeclaration("provider")!.getInitializer()!.compilerNode as ts.ObjectLiteralExpression;
+            const result = helper.parseProviderConfiguration(providerConfig);
+
+            expect(result).to.equal('TestProvider');
+        });
+
+        it('should return identifier for "useExisting" provider config', () => {
+            sourceFile = project.createSourceFile(sourceFileName, `const provider = {provide: 'test', useExisting: TestProvider};`);
+
+            const providerConfig = sourceFile.getVariableDeclaration("provider")!.getInitializer()!.compilerNode as ts.ObjectLiteralExpression;
+            const result = helper.parseProviderConfiguration(providerConfig);
+
+            expect(result).to.equal('TestProvider');
+        });
+    });
+});


### PR DESCRIPTION
# Fix parsing provider configuration object

Providers were not identified when we used an object config to inject them this PR should fix it.

I have found this issue https://github.com/compodoc/compodoc/issues/549  that i think is the same thing.

I also had to change the mocha config and ignore ts check in some files to run the unit test.

fix #549 