### PR TITLE
fix: input and output signals are listed in properties

### DIFF
--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -252,20 +252,14 @@ export class AngularDependencies extends FrameworkDependencies {
         if (IO.constructor && !Configuration.mainData.disableConstructors) {
             deps.constructorObj = IO.constructor;
         }
-        if (IO.inputs) {
-            deps.inputsClass = IO.inputs;
-        }
-        if (IO.outputs) {
-            deps.outputsClass = IO.outputs;
-        }
+        deps.inputsClass = IO.inputs ?? [];
+        deps.outputsClass = IO.outputs ?? [];
         if (IO.properties) {
-            deps.properties = IO.properties;
-            deps.inputsClass = deps.inputsClass
-                ? deps.inputsClass.concat(this.componentHelper.getInputSignals(IO.properties))
-                : this.componentHelper.getInputSignals(IO.properties);
-            deps.outputsClass = deps.outputsClass
-                ? deps.outputsClass.concat(this.componentHelper.getOutputSignals(IO.properties))
-                : this.componentHelper.getOutputSignals(IO.properties);
+            const {inputSignals, outputSignals, properties} = this.componentHelper.getInputOutputSignals(IO.properties);
+
+            deps.inputsClass = deps.inputsClass.concat(inputSignals)
+            deps.outputsClass = deps.outputsClass.concat(outputSignals)
+            deps.propertiesClass = properties;
         }
         if (IO.description) {
             deps.description = IO.description;

--- a/src/app/compiler/angular/deps/component-dep.factory.ts
+++ b/src/app/compiler/angular/deps/component-dep.factory.ts
@@ -89,12 +89,11 @@ export class ComponentDepFactory {
             componentDep.accessors = IO.accessors;
         }
         if (IO.properties) {
-            componentDep.inputsClass = componentDep.inputsClass.concat(
-                this.helper.getInputSignals(IO.properties)
-            );
-            componentDep.outputsClass = componentDep.outputsClass.concat(
-                this.helper.getOutputSignals(IO.properties)
-            );
+            const {inputSignals, outputSignals, properties} = this.helper.getInputOutputSignals(IO.properties);
+
+            componentDep.inputsClass = componentDep.inputsClass.concat(inputSignals)
+            componentDep.outputsClass = componentDep.outputsClass.concat(outputSignals)
+            componentDep.propertiesClass = properties;
         }
 
         return componentDep;

--- a/src/app/compiler/angular/deps/directive-dep.factory.ts
+++ b/src/app/compiler/angular/deps/directive-dep.factory.ts
@@ -26,8 +26,8 @@ export class DirectiveDepFactory {
 
             standalone: this.helper.getComponentStandalone(props, srcFile) ? true : false,
 
-            inputsClass: this.helper.getInputSignals(IO.properties).concat(IO.inputs),
-            outputsClass: this.helper.getOutputSignals(IO.properties).concat(IO.outputs),
+            inputsClass: IO.inputs,
+            outputsClass: IO.outputs,
 
             deprecated: IO.deprecated,
             deprecationMessage: IO.deprecationMessage,
@@ -57,6 +57,13 @@ export class DirectiveDepFactory {
         }
         if (IO.accessors) {
             directiveDeps.accessors = IO.accessors;
+        }
+        if (IO.properties) {
+            const {inputSignals, outputSignals, properties} = this.helper.getInputOutputSignals(IO.properties);
+
+            directiveDeps.inputsClass = directiveDeps.inputsClass.concat(inputSignals)
+            directiveDeps.outputsClass = directiveDeps.outputsClass.concat(outputSignals)
+            directiveDeps.propertiesClass = properties;
         }
         return directiveDeps;
     }

--- a/src/app/compiler/angular/deps/helpers/component-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/component-helper.ts
@@ -220,7 +220,7 @@ export class ComponentHelper {
 
             const result = {
                 required: !!required,
-                type,
+                type: this.parseSignalType(type),
                 defaultValue
             };
 
@@ -233,6 +233,32 @@ export class ComponentHelper {
 
             return result;
         }
+    }
+
+    public parseSignalType(type: string) {
+        if (!type) {
+            return type;
+        }
+
+        // adjust union string expression like: 'foo' | 'bar' | 'test'
+        // which should be outputed as: "foo" | "bar" | "test"
+
+        const unionTypeRegex = /^'([\w-]+)'\s?\|\s?('([\w-]+)'|.*)$/
+        let typeRest = type;
+        let newType = "";
+        let typeMatch: RegExpMatchArray;
+        while ((typeMatch = typeRest.match(unionTypeRegex))) {
+            const [, first, rest, second] = typeMatch;
+            if (second) {
+                newType += `"${first}" | "${second}"`;
+                type = newType;
+                break;
+            }
+            newType += `"${first}" | `;
+            typeRest = rest;
+        }
+
+        return type;
     }
 
     public getComponentStandalone(

--- a/src/app/compiler/angular/deps/helpers/component-helper.ts
+++ b/src/app/compiler/angular/deps/helpers/component-helper.ts
@@ -135,42 +135,58 @@ export class ComponentHelper {
         return this.symbolHelper.getSymbolDeps(props, 'inputs', srcFile);
     }
 
-    public getInputSignals(props) {
+    public getInputOutputSignals(props) {
         const inputSignals = [];
-        props?.forEach(prop => {
-            const config =
-                this.getSignalConfig('input', prop.defaultValue) ??
-                this.getSignalConfig('model', prop.defaultValue);
+        const outputSignals = [];
+        const properties = [];
 
-            if (config) {
-                const newInput = {
-                    ...prop,
-                    ...config
-                };
+        props.forEach(prop => {
+            const inputSignal = this.getInputSignal(prop);
+            if (inputSignal) {
+                inputSignals.push(inputSignal)
+            }
 
-                inputSignals.push(newInput);
+            const outputSignal = this.getOutputSignal(prop);
+            if (outputSignal) {
+                outputSignals.push(outputSignal)
+            }
+
+            if (!inputSignal && !outputSignal) {
+                properties.push(prop)
             }
         });
-        return inputSignals;
+
+        return {inputSignals, outputSignals, properties}
     }
 
-    public getOutputSignals(props) {
-        const outputSignals = [];
-        props?.forEach(prop => {
-            const config =
-                this.getSignalConfig('output', prop.defaultValue) ??
-                this.getSignalConfig('model', prop.defaultValue);
+    public getInputSignal(prop) {
+        const config =
+            this.getSignalConfig('input', prop.defaultValue) ??
+            this.getSignalConfig('model', prop.defaultValue);
 
-            if (config) {
-                const newInput = {
-                    ...prop,
-                    ...config
-                };
+        if (config) {
+            return  {
+                ...prop,
+                ...config
+            };
+        }
 
-                outputSignals.push(newInput);
-            }
-        });
-        return outputSignals;
+        return undefined;
+    }
+
+    public getOutputSignal(prop) {
+        const config =
+            this.getSignalConfig('output', prop.defaultValue) ??
+            this.getSignalConfig('model', prop.defaultValue);
+
+        if (config) {
+            return  {
+                ...prop,
+                ...config
+            };
+        }
+
+        return undefined;
     }
 
     private getSignalConfig(type: 'input' | 'output' | 'model', defaultValue: string) {

--- a/test/fixtures/sample-files/foo.component.ts
+++ b/test/fixtures/sample-files/foo.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, input, Output, output } from '@angular/core';
+import { Component, EventEmitter, Input, input, Output, output, model } from '@angular/core';
 
 /**
  * FooComponent description
@@ -85,6 +85,11 @@ export class FooComponent {
      * An example aliased output signal
      */
     public readonly aliasedOutputSignal = output(null, { alias: 'aliasedOutSignal' });
+
+    /**
+     * An example model input signal
+     */
+    public readonly modelInputSignal = model(0);
 
     /**
      * constructor description

--- a/test/fixtures/sample-files/foo.component.ts
+++ b/test/fixtures/sample-files/foo.component.ts
@@ -44,12 +44,12 @@ export class FooComponent {
     /**
      * An example aliased input using the object syntax
      */
-    @Input({ alias: 'aliasedInput' }) objectAliasedInput: string;
+    @Input({ alias: 'aliasedInputObjectSyntax' }) objectAliasedInput: string;
 
     /**
      * An example aliased required input using the object syntax
      */
-    @Input({ alias: 'aliasedInput', required: true }) aliasedAndRequired: string;
+    @Input({ alias: 'aliasedAndRequiredInput', required: true }) aliasedAndRequired: string;
 
     /**
      * An example output

--- a/test/fixtures/todomvc-ng2/src/app/about/compodoc/compodoc.component.ts
+++ b/test/fixtures/todomvc-ng2/src/app/about/compodoc/compodoc.component.ts
@@ -50,15 +50,10 @@ export class CompodocComponent {
      */
 
     outputSignal = output();
-    outputSignalWithDefaultValue = output(this.defaultValue);
-    outputSignalWithDefaultStringValue = output('value');
-    outputSignalWithAlias = output(0, { alias: 'aliasedSignal' });
+    outputSignalWithAlias = output({ alias: 'aliasedSignal' });
 
-    requiredOutputSignal = output.required();
-    requiredOutputSignalWithType = output.required<number>();
-
-    outputSignalWithType = output<string>('value');
-    outputSignalWithStringType = output<'value'>('value');
-    outputSignalWithMultipleTypes = output<string | number>(0);
-    outputSignalWithMultipleMixedTypes = output<'asc' | 'dsc' | number>('asc');
+    outputSignalWithType = output<string>();
+    outputSignalWithStringType = output<'value'>();
+    outputSignalWithMultipleTypes = output<string | number>();
+    outputSignalWithMultipleMixedTypes = output<'asc' | 'dsc' | number>();
 }

--- a/test/src/cli/cli-generation-big-app.spec.ts
+++ b/test/src/cli/cli-generation-big-app.spec.ts
@@ -1343,161 +1343,25 @@ describe('CLI simple generation - big app', () => {
             );
         });
 
-        it('should support output signals with a default value', () => {
-            const file = read(distFolder + '/components/CompodocComponent.html');
-
-            expect(file).to.contain(
-                `<tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="outputSignalWithDefaultValue"></a>
-                    <span class="name">
-                        <span ><b>outputSignalWithDefaultValue</b></span>
-                        <a href="#outputSignalWithDefaultValue"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
-                <tr>
-                    <td class="col-md-4">
-                        <i>Default value : </i><code>output(this.defaultValue)</code>
-                    </td>
-                </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="53" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:53</a></div>
-                        </td>
-                    </tr>
-
-
-        </tbody>`
-            );
-        });
-
-        it('should support output signals a default quoted value', () => {
-            const file = read(distFolder + '/components/CompodocComponent.html');
-
-            expect(file).to.contain(
-                `<table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="outputSignalWithDefaultStringValue"></a>
-                    <span class="name">
-                        <span ><b>outputSignalWithDefaultStringValue</b></span>
-                        <a href="#outputSignalWithDefaultStringValue"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
-                <tr>
-                    <td class="col-md-4">
-                        <i>Default value : </i><code>output(&#x27;value&#x27;)</code>
-                    </td>
-                </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="54" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:54</a></div>
-                        </td>
-                    </tr>
-
-
-        </tbody>
-    </table>`
-            );
-        });
-
         it('should support output signals with an alias', () => {
             const file = read(distFolder + '/components/CompodocComponent.html');
 
             expect(file).to.contain(
                 `<table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="outputSignalWithAlias"></a>
-                    <span class="name">
-                        <span ><b>outputSignalWithAlias</b></span>
-                        <a href="#outputSignalWithAlias"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
+            <tbody>
                 <tr>
                     <td class="col-md-4">
-                        <i>Default value : </i><code>output(0, { alias: &#x27;aliasedSignal&#x27; })</code>
+                        <a name="outputSignalWithAlias"></a>
+                        <b>outputSignalWithAlias</b>
                     </td>
                 </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="55" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:55</a></div>
-                        </td>
-                    </tr>
-
-
-        </tbody>
-    </table>`
-            );
-        });
-
-        it('should support required output signals', () => {
-            const file = read(distFolder + '/components/CompodocComponent.html');
-
-            expect(file).to.contain(
-                `<table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="requiredOutputSignal"></a>
-                    <span class="name">
-                        <span ><b>requiredOutputSignal</b></span>
-                        <a href="#requiredOutputSignal"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
-                <tr>
-                    <td class="col-md-4">
-                        <i>Default value : </i><code>output.required()</code>
-                    </td>
-                </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="57" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:57</a></div>
-                        </td>
-                    </tr>
-
-
-        </tbody>
-    </table>`
-            );
-        });
-
-        it('should support required output signals with a type ', () => {
-            const file = read(distFolder + '/components/CompodocComponent.html');
-
-            expect(file).to.contain(
-                `<table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="requiredOutputSignalWithType"></a>
-                    <span class="name">
-                        <span ><b>requiredOutputSignalWithType</b></span>
-                        <a href="#requiredOutputSignalWithType"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
-                <tr>
-                    <td class="col-md-4">
-                        <i>Default value : </i><code>output.required&lt;number&gt;()</code>
-                    </td>
-                </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="58" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:58</a></div>
-                        </td>
-                    </tr>
-
-
-        </tbody>
-    </table>`
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="53" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:53</a></div>
+                            </td>
+                        </tr>
+            </tbody>
+        </table>`
             );
         });
 
@@ -1521,7 +1385,7 @@ describe('CLI simple generation - big app', () => {
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="60" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:60</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="55" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:55</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1534,30 +1398,26 @@ describe('CLI simple generation - big app', () => {
 
             expect(file).to.contain(
                 `<table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="outputSignalWithStringType"></a>
-                    <span class="name">
-                        <span ><b>outputSignalWithStringType</b></span>
-                        <a href="#outputSignalWithStringType"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
+            <tbody>
                 <tr>
                     <td class="col-md-4">
-                        <i>Default value : </i><code>output&lt;&#x27;value&#x27;&gt;(&#x27;value&#x27;)</code>
+                        <a name="outputSignalWithStringType"></a>
+                        <b>outputSignalWithStringType</b>
                     </td>
                 </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="61" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:61</a></div>
-                        </td>
-                    </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>    <code>&#x27;value&#x27;</code>
 
-
-        </tbody>
-    </table>`
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="56" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:56</a></div>
+                            </td>
+                        </tr>
+            </tbody>
+        </table>`
             );
         });
 
@@ -1581,7 +1441,7 @@ describe('CLI simple generation - big app', () => {
                 </tr>
                         <tr>
                             <td class="col-md-2" colspan="2">
-                                    <div class="io-line">Defined in <a href="" data-line="62" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:62</a></div>
+                                    <div class="io-line">Defined in <a href="" data-line="57" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:57</a></div>
                             </td>
                         </tr>
             </tbody>
@@ -1593,31 +1453,27 @@ describe('CLI simple generation - big app', () => {
             const file = read(distFolder + '/components/CompodocComponent.html');
 
             expect(file).to.contain(
-                ` <table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="outputSignalWithMultipleMixedTypes"></a>
-                    <span class="name">
-                        <span ><b>outputSignalWithMultipleMixedTypes</b></span>
-                        <a href="#outputSignalWithMultipleMixedTypes"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
+                `<table class="table table-sm table-bordered">
+            <tbody>
                 <tr>
                     <td class="col-md-4">
-                        <i>Default value : </i><code>output&lt;&#x27;asc&#x27; | &#x27;dsc&#x27; | number&gt;(&#x27;asc&#x27;)</code>
+                        <a name="outputSignalWithMultipleMixedTypes"></a>
+                        <b>outputSignalWithMultipleMixedTypes</b>
                     </td>
                 </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="63" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:63</a></div>
-                        </td>
-                    </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>    <code>&#x27;asc&#x27; | &#x27;dsc&#x27; | number</code>
 
-
-        </tbody>
-    </table>`
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="58" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:58</a></div>
+                            </td>
+                        </tr>
+            </tbody>
+        </table>`
             );
         });
     });
@@ -1891,30 +1747,31 @@ describe('CLI simple generation - big app', () => {
 
             expect(file).to.contain(
                 `<table class="table table-sm table-bordered">
-        <tbody>
-            <tr>
-                <td class="col-md-4">
-                    <a name="modelSignalWithMultipleMixedTypes"></a>
-                    <span class="name">
-                        <span ><b>modelSignalWithMultipleMixedTypes</b></span>
-                        <a href="#modelSignalWithMultipleMixedTypes"><span class="icon ion-ios-link"></span></a>
-                    </span>
-                </td>
-            </tr>
+            <tbody>
                 <tr>
                     <td class="col-md-4">
-                        <i>Default value : </i><code>model&lt;&#x27;asc&#x27; | &#x27;dsc&#x27; | number&gt;(&#x27;asc&#x27;)</code>
+                        <a name="modelSignalWithMultipleMixedTypes"></a>
+                        <b>modelSignalWithMultipleMixedTypes</b>
                     </td>
                 </tr>
-                    <tr>
-                        <td class="col-md-4">
-                                <div class="io-line">Defined in <a href="" data-line="46" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:46</a></div>
-                        </td>
-                    </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>    <code>&#x27;asc&#x27; | &#x27;dsc&#x27; | number</code>
 
-
-        </tbody>
-    </table>`
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Default value : </i><code>&#x27;asc&#x27;</code>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="46" class="link-to-prism">src/app/about/compodoc/compodoc.component.ts:46</a></div>
+                            </td>
+                        </tr>
+            </tbody>
+        </table>`
             );
         });
     });

--- a/test/src/cli/cli-generation.spec.ts
+++ b/test/src/cli/cli-generation.spec.ts
@@ -146,6 +146,412 @@ describe('CLI simple generation', () => {
         });
 
         /**
+         * inputs outputs
+         */
+        it('should generate inputs', () => {
+           expect(fooComponentFile).to.contain(`<h3 id="inputs">Inputs</h3>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="aliasedAndRequiredInput"></a>
+                        <b>aliasedAndRequiredInput</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank" >string</a></code>
+
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Required : </i>&nbsp;<b>true</b>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="52" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:52</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example aliased required input using the object syntax</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="aliasedInput"></a>
+                        <b>aliasedInput</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank" >string</a></code>
+
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="42" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:42</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example aliased input</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="aliasedInputObjectSyntax"></a>
+                        <b>aliasedInputObjectSyntax</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank" >string</a></code>
+
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="47" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:47</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example aliased input using the object syntax</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="exampleInput"></a>
+                        <b>exampleInput</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank" >string</a></code>
+
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Default value : </i><code>&#x27;foo&#x27;</code>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="32" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:32</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example input
+<a href="../components/BarComponent.html">BarComponent</a> or <a href="../components/BarComponent.html">BarComponent2</a> or <a href="../components/BarComponent.html">BarComponent3</a></p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="requiredInput"></a>
+                        <b>requiredInput</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank" >string</a></code>
+
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Required : </i>&nbsp;<b>true</b>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="37" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:37</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example required input</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="aliasedInputSignal"></a>
+                        <b>aliasedInputSignal</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Default value : </i><code>null, { alias: &#x27;aliasedInSignal&#x27; }</code>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="72" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:72</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example aliased input signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="inputSignal"></a>
+                        <b>inputSignal</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="../miscellaneous/functions.html#foo" target="_self" >&#x27;foo&#x27; | &#x27;bar&#x27;</a></code>
+
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Default value : </i><code>&#x27;foo&#x27;</code>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="62" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:62</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example input signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="modelInputSignal"></a>
+                        <b>modelInputSignal</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Default value : </i><code>0</code>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="92" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:92</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example model input signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="requiredInputSignal"></a>
+                        <b>requiredInputSignal</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank" >string</a></code>
+
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Required : </i>&nbsp;<b>true</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Default value : </i><code>&#x27;foo&#x27;</code>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="67" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:67</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example required input signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>`)
+        });
+
+        it('should generate outputs', () => {
+            expect(fooComponentFile).to.contain(`<h3 id="outputs">Outputs</h3>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="exampleOutput"></a>
+                        <b>exampleOutput</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>    <code>EventEmitter&lt;literal type&gt;</code>
+
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="57" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:57</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example output</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="aliasedOutputSignal"></a>
+                        <b>aliasedOutputSignal</b>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="87" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:87</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example aliased output signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="modelInputSignal"></a>
+                        <b>modelInputSignal</b>
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="92" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:92</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example model input signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="outputSignal"></a>
+                        <b>outputSignal</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="../miscellaneous/functions.html#foo" target="_self" >&#x27;foo&#x27; | &#x27;bar&#x27;</a></code>
+
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="77" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:77</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example output signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <table class="table table-sm table-bordered">
+            <tbody>
+                <tr>
+                    <td class="col-md-4">
+                        <a name="requiredOutputSignal"></a>
+                        <b>requiredOutputSignal</b>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <i>Type : </i>        <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/string" target="_blank" >string</a></code>
+
+                    </td>
+                </tr>
+                        <tr>
+                            <td class="col-md-2" colspan="2">
+                                    <div class="io-line">Defined in <a href="" data-line="82" class="link-to-prism">test/fixtures/sample-files/foo.component.ts:82</a></div>
+                            </td>
+                        </tr>
+                <tr>
+                    <td class="col-md-4">
+                        <div class="io-description"><p>An example required output signal</p>
+</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>`)
+        });
+
+        /**
          * No graph for empty module
          */
 


### PR DESCRIPTION
Currently all `input`, `output` and `model` signals are listed twice in the properties section and in the inputs or outputs section. See this screenshot after running `npm run test:simple-doc`:

![image](https://github.com/user-attachments/assets/33837f38-ff50-4cd0-bdb2-6bff060fb8e3)

This PR fixes this bug by removing the entry in the properties section if it is a `input`, `output` or `model` signal. See this screenshot with this fix applied.

![image](https://github.com/user-attachments/assets/a04a3eff-a1ff-4f51-a3ed-732657d8a25d)

If I should add tests for this change, could you please give me an advice where I can find the corresponding test file.