### PR TITLE
fix: unit test for input output signal

### DIFF
--- a/src/app/compiler/angular-dependencies.ts
+++ b/src/app/compiler/angular-dependencies.ts
@@ -259,7 +259,7 @@ export class AngularDependencies extends FrameworkDependencies {
 
             deps.inputsClass = deps.inputsClass.concat(inputSignals)
             deps.outputsClass = deps.outputsClass.concat(outputSignals)
-            deps.propertiesClass = properties;
+            deps.properties = properties;
         }
         if (IO.description) {
             deps.description = IO.description;

--- a/test/src/cli/cli-generation.spec.ts
+++ b/test/src/cli/cli-generation.spec.ts
@@ -337,7 +337,7 @@ describe('CLI simple generation', () => {
                 </tr>
                 <tr>
                     <td class="col-md-4">
-                        <i>Type : </i>        <code><a href="../miscellaneous/functions.html#foo" target="_self" >&#x27;foo&#x27; | &#x27;bar&#x27;</a></code>
+                        <i>Type : </i>        <code><a href="../miscellaneous/functions.html#foo" target="_self" >&quot;foo&quot; | &quot;bar&quot;</a></code>
 
                     </td>
                 </tr>
@@ -505,7 +505,7 @@ describe('CLI simple generation', () => {
                 </tr>
                 <tr>
                     <td class="col-md-4">
-                        <i>Type : </i>        <code><a href="../miscellaneous/functions.html#foo" target="_self" >&#x27;foo&#x27; | &#x27;bar&#x27;</a></code>
+                        <i>Type : </i>        <code><a href="../miscellaneous/functions.html#foo" target="_self" >&quot;foo&quot; | &quot;bar&quot;</a></code>
 
                     </td>
                 </tr>


### PR DESCRIPTION
Followup fix for bug introduced in #1549. This PR contains the changes from #1577 and also fixes two test cases. So all tests should be green again.