### PR TITLE
fix(app): fix logger padding issue

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -44,7 +44,7 @@ class Logger {
 
     private format(level, ...args) {
         let pad = (s, l, z = '') => {
-            return s + Array(Math.max(0, l - s.length + 1)).join(z);
+            return s + Array(Math.max(0, l - (s.length ?? 0) + 1)).join(z);
         };
 
         let msg = args.join(' ');


### PR DESCRIPTION
Fix the following error:

```ts
[16:43:59] parsing        : /Users/go/Documents/work/app/scripts/bump-version.ts
/Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:74
            return s + Array(Math.max(0, l - s.length + 1)).join(c);
                       ^

RangeError: Invalid array length
    at pad (/Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:74:24)
    at Logger.format (/Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:78:19)
    at Logger.error (/Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:56:33)
    at /Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:1561:32
    at Array.map (<anonymous>)
    at Dependencies.getDependencies (/Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:1552:21)
    at Application.getDependenciesData (/Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:2914:40)
    at /Users/go/.npm/_npx/3cd04f73936070ae/node_modules/compodoc/dist/index-cli.js:2897:19
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

With this fix, it now creates the following log:

```
[16:33:39] Error: Debug Failure. False expression: should not get here               : /Users/go/Documents/work/app/scripts/bump-version.ts
```