### PR TITLE
feat: Add disableOverview flag

### DIFF
--- a/src-refactored/core/entities/public-configuration.ts
+++ b/src-refactored/core/entities/public-configuration.ts
@@ -21,6 +21,8 @@ export class PublicConfiguration {
     public disableSourceCode: boolean;
     public disableStyleTab: boolean;
     public disableTemplateTab: boolean;
+    public disableProperties: boolean;
+    public disableOverview: boolean;
     public exportFormat: string;
     public extTheme: string;
     public files: string;

--- a/src-refactored/core/entities/public-configuration.ts
+++ b/src-refactored/core/entities/public-configuration.ts
@@ -21,7 +21,6 @@ export class PublicConfiguration {
     public disableSourceCode: boolean;
     public disableStyleTab: boolean;
     public disableTemplateTab: boolean;
-    public disableProperties: boolean;
     public disableOverview: boolean;
     public exportFormat: string;
     public extTheme: string;

--- a/src-refactored/core/entities/public-flags.ts
+++ b/src-refactored/core/entities/public-flags.ts
@@ -142,6 +142,18 @@ export const PUBLIC_FLAGS: Flag[] = [
         defaultValue: false
     },
     {
+        label: 'disableProperties',
+        flag: '--disableProperties',
+        description: 'Do not add the properties list',
+        defaultValue: COMPODOC_DEFAULTS.disableProperties
+    },
+    {
+        label: 'disableOverview',
+        flag: '--disableOverview',
+        description: 'Do not add the overview page',
+        defaultValue: false
+    },
+    {
         label: 'exportFormat',
         flag: '-e, --exportFormat [format]',
         description: 'Export in specified format (json, html)',
@@ -265,36 +277,4 @@ export const PUBLIC_FLAGS: Flag[] = [
     {
         label: 'theme',
         flag: '--theme [theme]',
-        description: `Choose one of available themes, default is 'gitbook' (laravel, original, material, postmark, readthedocs, stripe, vagrant)`,
-        defaultValue: COMPODOC_DEFAULTS.theme
-    },
-    {
-        label: 'toggleMenuItems',
-        flag: '--toggleMenuItems <items>',
-        description: `Close by default items in the menu values : ['all'] or one of these ['modules','components','directives','controllers','classes','injectables','guards','interfaces','interceptors','pipes','miscellaneous','additionalPages']`,
-        defaultValue: COMPODOC_DEFAULTS.toggleMenuItems,
-        parsingFunction: list
-    },
-    {
-        label: 'tsconfig',
-        flag: '-p, --tsconfig [config]',
-        description: 'A tsconfig.json file'
-    },
-    {
-        label: 'unitTestCoverage',
-        flag: '--unitTestCoverage [json-summary]',
-        description: 'To include unit test coverage, specify istanbul JSON coverage summary file'
-    },
-    {
-        label: 'watch',
-        flag: '-w, --watch',
-        description: 'Watch source files after serve and force documentation rebuild',
-        defaultValue: false
-    },
-    {
-        label: 'maxSearchResults',
-        flag: '--maxSearchResults [number]',
-        description: 'Max search results on the results page. To show all results, set to 0',
-        defaultValue: 15
-    }
-];
+        description: `

--- a/src-refactored/core/entities/public-flags.ts
+++ b/src-refactored/core/entities/public-flags.ts
@@ -271,4 +271,36 @@ export const PUBLIC_FLAGS: Flag[] = [
     {
         label: 'theme',
         flag: '--theme [theme]',
-        description: `
+        description: `Choose one of available themes, default is 'gitbook' (laravel, original, material, postmark, readthedocs, stripe, vagrant)`,
+        defaultValue: COMPODOC_DEFAULTS.theme
+    },
+    {
+        label: 'toggleMenuItems',
+        flag: '--toggleMenuItems <items>',
+        description: `Close by default items in the menu values : ['all'] or one of these ['modules','components','directives','controllers','classes','injectables','guards','interfaces','interceptors','pipes','miscellaneous','additionalPages']`,
+        defaultValue: COMPODOC_DEFAULTS.toggleMenuItems,
+        parsingFunction: list
+    },
+    {
+        label: 'tsconfig',
+        flag: '-p, --tsconfig [config]',
+        description: 'A tsconfig.json file'
+    },
+    {
+        label: 'unitTestCoverage',
+        flag: '--unitTestCoverage [json-summary]',
+        description: 'To include unit test coverage, specify istanbul JSON coverage summary file'
+    },
+    {
+        label: 'watch',
+        flag: '-w, --watch',
+        description: 'Watch source files after serve and force documentation rebuild',
+        defaultValue: false
+    },
+    {
+        label: 'maxSearchResults',
+        flag: '--maxSearchResults [number]',
+        description: 'Max search results on the results page. To show all results, set to 0',
+        defaultValue: 15
+    }
+];

--- a/src-refactored/core/entities/public-flags.ts
+++ b/src-refactored/core/entities/public-flags.ts
@@ -142,12 +142,6 @@ export const PUBLIC_FLAGS: Flag[] = [
         defaultValue: false
     },
     {
-        label: 'disableProperties',
-        flag: '--disableProperties',
-        description: 'Do not add the properties list',
-        defaultValue: COMPODOC_DEFAULTS.disableProperties
-    },
-    {
         label: 'disableOverview',
         flag: '--disableOverview',
         description: 'Do not add the overview page',

--- a/src/app/application.ts
+++ b/src/app/application.ts
@@ -340,13 +340,15 @@ export class Application {
                             });
                             if (markdowns[i] === 'readme') {
                                 Configuration.mainData.readme = true;
-                                Configuration.addPage({
-                                    name: 'overview',
-                                    id: 'overview',
-                                    context: 'overview',
-                                    depth: 0,
-                                    pageType: COMPODOC_DEFAULTS.PAGE_TYPES.ROOT
-                                });
+                                if (!Configuration.mainData.disableOverview) {
+                                    Configuration.addPage({
+                                        name: 'overview',
+                                        id: 'overview',
+                                        context: 'overview',
+                                        depth: 0,
+                                        pageType: COMPODOC_DEFAULTS.PAGE_TYPES.ROOT
+                                    });
+                                }
                             } else {
                                 Configuration.mainData.markdowns.push({
                                     name: markdowns[i],
@@ -363,13 +365,15 @@ export class Application {
                             logger.warn(errorMessage);
                             logger.warn(`Continuing without ${markdowns[i].toUpperCase()}.md file`);
                             if (markdowns[i] === 'readme') {
-                                Configuration.addPage({
-                                    name: 'index',
-                                    id: 'index',
-                                    context: 'overview',
-                                    depth: 0,
-                                    pageType: COMPODOC_DEFAULTS.PAGE_TYPES.ROOT
-                                });
+                                if (!Configuration.mainData.disableOverview) {
+                                    Configuration.addPage({
+                                        name: 'index',
+                                        id: 'index',
+                                        context: 'overview',
+                                        depth: 0,
+                                        pageType: COMPODOC_DEFAULTS.PAGE_TYPES.ROOT
+                                    });
+                                }
                             }
                             i++;
                             loop();

--- a/src/app/configuration.ts
+++ b/src/app/configuration.ts
@@ -68,6 +68,7 @@ export class Configuration implements ConfigurationInterface {
         disableSearch: false,
         disableDependencies: COMPODOC_DEFAULTS.disableDependencies,
         disableProperties: COMPODOC_DEFAULTS.disableProperties,
+        disableOverview: COMPODOC_DEFAULTS.disableOverview,
         watch: false,
         mainGraph: '',
         coverageTest: false,

--- a/src/app/interfaces/configuration-file.interface.ts
+++ b/src/app/interfaces/configuration-file.interface.ts
@@ -39,6 +39,7 @@ export interface ConfigurationFileInterface {
     disableSearch: boolean;
     disableDependencies: boolean;
     disableProperties: boolean;
+    disableOverview: boolean;
     minimal: boolean;
     customFavicon: string;
     customLogo: string;

--- a/src/app/interfaces/main-data.interface.ts
+++ b/src/app/interfaces/main-data.interface.ts
@@ -59,6 +59,7 @@ export interface MainDataInterface {
     disableSearch: boolean;
     disableDependencies: boolean;
     disableProperties: boolean;
+    disableOverview: boolean;
     watch: boolean;
     mainGraph: string;
     coverageTest: boolean;

--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -298,6 +298,13 @@
             "default": false,
             "examples": [false]
         },
+        "disableOverview": {
+            "$id": "/properties/disableOverview",
+            "type": "boolean",
+            "title": "Do not add the overview page",
+            "default": false,
+            "examples": [false]
+        },
         "minimal": {
             "$id": "/properties/minimal",
             "type": "boolean",

--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -185,6 +185,7 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
                 'Do not add the properties list',
                 COMPODOC_DEFAULTS.disableProperties
             )
+            .option('--disableOverview', 'Do not add the overview page', false)
             .option(
                 '--minimal',
                 'Minimal mode with only documentation. No search, no graph, no coverage.',
@@ -544,6 +545,13 @@ Note: Certain tabs will only be shown if applicable to a given dependency`,
         }
         if (programOptions.disableProperties) {
             Configuration.mainData.disableProperties = programOptions.disableProperties;
+        }
+
+        if (configFile.disableOverview) {
+            Configuration.mainData.disableOverview = configFile.disableOverview;
+        }
+        if (programOptions.disableOverview) {
+            Configuration.mainData.disableOverview = programOptions.disableOverview;
         }
 
         if (configFile.minimal) {

--- a/src/templates/partials/menu.hbs
+++ b/src/templates/partials/menu.hbs
@@ -30,23 +30,33 @@ customElements.define('compodoc-menu', class extends HTMLElement {
                     <a data-type="chapter-link" href="index.html"><span class="icon ion-ios-home"></span>{{t "getting-started"
                         }}</a>
                     <ul class="links">
+                        {{#unless disableOverview}}
+                            {{#if readme}}
+                                <li class="link">
+                                    <a href="overview.html" data-type="chapter-link">
+                                        <span class="icon ion-ios-keypad"></span>{{t "overview"}}
+                                    </a>
+                                </li>
+                            {{else}}
+                                <li class="link">
+                                    <a href="index.html" data-type="chapter-link">
+                                        <span class="icon ion-ios-keypad"></span>{{t "overview"}}
+                                    </a>
+                                </li>
+                            {{/if}}
+                        {{/unless}}
+
                         {{#if readme}}
-                        <li class="link">
-                            <a href="overview.html" data-type="chapter-link">
-                                <span class="icon ion-ios-keypad"></span>{{t "overview" }}
-                            </a>
-                        </li>
-                        <li class="link">
-                            <a href="index.html" data-type="chapter-link">
-                                <span class="icon ion-ios-paper"></span>{{t "readme" }}
-                            </a>
-                        </li>
-                        {{else}}
-                        <li class="link">
-                            <a href="index.html" data-type="chapter-link">
-                                <span class="icon ion-ios-keypad"></span>{{t "overview" }}
-                            </a>
-                        </li>
+                            <li class="link">
+                                <a href="index.html" data-type="chapter-link">
+                                    <span class="icon ion-ios-paper"></span>
+                                    {{#if disableOverview}}
+                                        {{t "overview"}}
+                                    {{else}}
+                                        {{t "readme"}}
+                                    {{/if}}
+                                </a>
+                            </li>
                         {{/if}}
                         {{#each markdowns}}
                         <li class="link">

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -29,6 +29,7 @@ export const COMPODOC_DEFAULTS = {
     disableRoutesGraph: false,
     disableDependencies: false,
     disableProperties: false,
+    disableOverview: false,
     PAGE_TYPES: {
         ROOT: 'root',
         INTERNAL: 'internal'


### PR DESCRIPTION
Overview page is very simple and not that useful as only one of the items is a link, the purpose of this pull-request is to add the option to the developer to decide not having this page.