### PR TITLE
fix: add missing disableFilePath property to schema.json

### DIFF
--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -298,6 +298,13 @@
             "default": false,
             "examples": [false]
         },
+        "disableFilePath": {
+            "$id": "/properties/disableFilePath",
+            "type": "boolean",
+            "title": "Do not add the file path",
+            "default": false,
+            "examples": [false]
+        },
         "disableOverview": {
             "$id": "/properties/disableOverview",
             "type": "boolean",


### PR DESCRIPTION
When the disableFilePath feature was added I forgot to add it to the schema.json and this causes that it cannot be configured using .compodocrc.json file.

This fix add the property to the schema.json