### PR TITLE
fix(compiler): emit optional flag for decorator inputs

### DIFF
--- a/src/app/compiler/angular/deps/helpers/class-member.visitor.ts
+++ b/src/app/compiler/angular/deps/helpers/class-member.visitor.ts
@@ -727,6 +727,8 @@ export class ClassMemberVisitor {
             : undefined;
         Object.assign(_return, this.context.initializeDocumentationFields());
 
+        _return.optional = typeof property.questionToken !== 'undefined';
+
         if (inArgs.length > 0 && inArgs[0].properties && hasRequiredField) {
             _return.optional = getRequiredField().initializer.kind !== SyntaxKind.TrueKeyword;
         }

--- a/test/fixtures/issue863-optional-input/src/app/optional-input.component.ts
+++ b/test/fixtures/issue863-optional-input/src/app/optional-input.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'app-optional-input',
+    template: ''
+})
+export class OptionalInputComponent {
+    @Input() optionalInput?: string;
+
+    @Input() mandatoryInput: string;
+
+    @Input({ required: true }) explicitlyRequiredInput?: string;
+
+    optionalProperty?: string;
+}

--- a/test/fixtures/issue863-optional-input/tsconfig.json
+++ b/test/fixtures/issue863-optional-input/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs"
+  },
+  "include": ["src/**/*"]
+}

--- a/test/src/app/compiler/angular/deps/helpers/class-helper.spec.ts
+++ b/test/src/app/compiler/angular/deps/helpers/class-helper.spec.ts
@@ -1064,6 +1064,96 @@ describe('ClassHelper', () => {
             expect(result.optional).to.be.false;
         });
 
+        it('should mark an @Input declared with a question token as optional', () => {
+            const property = {
+                name: { text: 'optionalProp', kind: SyntaxKind.Identifier },
+                type: { kind: SyntaxKind.StringKeyword },
+                questionToken: { kind: SyntaxKind.QuestionToken },
+                initializer: undefined,
+                jsDoc: [],
+                kind: SyntaxKind.PropertyDeclaration,
+                pos: 10,
+                end: 20
+            } as any;
+
+            const decorator = {
+                expression: {
+                    arguments: []
+                }
+            } as any;
+
+            const result = (classHelper as any).visitInputAndHostBinding(
+                property,
+                decorator,
+                mockSourceFile
+            );
+
+            expect(result.optional).to.be.true;
+        });
+
+        it('should mark an @Input without a question token as not optional', () => {
+            const property = {
+                name: { text: 'requiredProp', kind: SyntaxKind.Identifier },
+                type: { kind: SyntaxKind.StringKeyword },
+                initializer: undefined,
+                jsDoc: [],
+                kind: SyntaxKind.PropertyDeclaration,
+                pos: 10,
+                end: 20
+            } as any;
+
+            const decorator = {
+                expression: {
+                    arguments: []
+                }
+            } as any;
+
+            const result = (classHelper as any).visitInputAndHostBinding(
+                property,
+                decorator,
+                mockSourceFile
+            );
+
+            expect(result.optional).to.be.false;
+        });
+
+        it('should let an explicit required config win over the question token', () => {
+            const property = {
+                name: { text: 'configuredProp', kind: SyntaxKind.Identifier },
+                type: { kind: SyntaxKind.StringKeyword },
+                questionToken: { kind: SyntaxKind.QuestionToken },
+                initializer: undefined,
+                jsDoc: [],
+                kind: SyntaxKind.PropertyDeclaration,
+                pos: 10,
+                end: 20
+            } as any;
+
+            const mockObjectLiteral = {
+                kind: SyntaxKind.ObjectLiteralExpression,
+                properties: [
+                    {
+                        name: { escapedText: 'required' },
+                        initializer: { kind: SyntaxKind.TrueKeyword }
+                    }
+                ]
+            };
+
+            const decorator = {
+                expression: {
+                    arguments: [mockObjectLiteral]
+                }
+            } as any;
+
+            const result = (classHelper as any).visitInputAndHostBinding(
+                property,
+                decorator,
+                mockSourceFile
+            );
+
+            expect(result.optional).to.be.false;
+        });
+
         it('should extract jsdoc tags and description even when property.jsDoc is missing (issue #1441)', () => {
             const property = {
                 name: { text: 'internalOverrideInput', kind: SyntaxKind.Identifier },

--- a/test/src/cli/cli-issue-863-optional-input.spec.ts
+++ b/test/src/cli/cli-issue-863-optional-input.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { temporaryDir, shell, read } from '../helpers';
+
+const tmp = temporaryDir();
+
+describe('CLI issue #863 - optional flag on decorator inputs', () => {
+    const distFolder = tmp.name + '-issue-863';
+    let component;
+
+    const inputNamed = name => component.inputsClass.find(input => input.name === name);
+
+    before(done => {
+        tmp.create(distFolder);
+
+        const command = shell('node', [
+            './bin/index-cli.js',
+            '-p',
+            './test/fixtures/issue863-optional-input/tsconfig.json',
+            '--silent',
+            '-e',
+            'json',
+            '-d',
+            distFolder
+        ]);
+
+        if (command.stderr.toString() !== '') {
+            console.error(`shell error: ${command.stderr.toString()}`);
+            done('error');
+            return;
+        }
+
+        const documentationJson = JSON.parse(read(`${distFolder}/documentation.json`));
+        component = documentationJson.components.find(
+            comp => comp.name === 'OptionalInputComponent'
+        );
+        done();
+    });
+
+    after(() => tmp.clean(distFolder));
+
+    it('should mark an optional decorator input as optional', () => {
+        expect(inputNamed('optionalInput').optional).to.be.true;
+    });
+
+    it('should not mark a non-optional decorator input as optional', () => {
+        expect(inputNamed('mandatoryInput').optional).to.be.false;
+    });
+
+    it('should let an explicit required config win over the question token', () => {
+        expect(inputNamed('explicitlyRequiredInput').optional).to.be.false;
+    });
+
+    it('should report a decorator input the same way as an equivalent plain property', () => {
+        const plainProperty = component.propertiesClass.find(
+            property => property.name === 'optionalProperty'
+        );
+
+        expect(inputNamed('optionalInput').optional).to.equal(plainProperty.optional);
+    });
+});


### PR DESCRIPTION
Hi! Following up on the conversation we started in #1755 with a much smaller change first.

## The problem

Compodoc tells consumers whether a class member is optional, except for one case. A signal input carries the `optional` flag. A plain class property carries it. An `@Input()`-decorated property does not carry it at all, unless the decorator happens to be called with an object literal containing a `required` key.

So the same component, documented two ways, reports two different things:

```ts
@Component({ selector: 'app-demo', template: '' })
export class DemoComponent {
  @Input() decoratorOptional?: string;  // no `optional` key at all
  plainOptional?: string;               // "optional": true
}
```

Anything computing "is this required" from the flag therefore treats every decorator input as mandatory. A component with ten inputs where two are genuinely required presents all ten as required.

This was reported in #863 back in 2019. It was never fixed, the stale bot closed it, and the reporter had offered to fix it himself but asked for a pointer to the source file and did not get one. It still reproduces on 2.0.0, so here is both the pointer and the fix.

## The change

In `visitInputAndHostBinding`, `optional` is only assigned inside the branch that handles `@Input({ required: ... })`. `property.questionToken` is never consulted.

That makes it the only member-entry builder in `class-member.visitor.ts` that skips the check. The visitors for plain properties, methods, arguments and type-literal members all do `typeof x.questionToken !== 'undefined'`.

The fix is that one line, placed before the existing `required`-derived assignment so an explicit `@Input({ required: true })` still wins and its output is byte-identical to today's.

## Compatibility

Rendered HTML is unchanged for inputs: the inputs partial reads `required`, never `optional`. The only rendered surface that reads `optional` and is reachable from this function is `@HostBinding`, which renders through the property partial. A host binding declared with a question token would now show an "Optional" badge, which seems right, and no fixture declares one.

The JSON export gains the key, which is the point of the change and is additive.

The existing `visitInputAndHostBinding` test asserting `optional === false` for `@Input({ alias, required: true })` still passes unchanged.

## Tests

Three unit tests on `visitInputAndHostBinding` covering a decorator input with a question token, one without, and one where an explicit `required` config overrides the question token.

One integration test with its own fixture, asserting on emitted `documentation.json`, including that a decorator input and an equivalent plain property now report the same thing. I added a separate fixture directory rather than extending `sample-files`, since the generation spec pins that component's HTML verbatim including source line numbers.

Full suite green locally on Node 24 (1064 passing).

## Why I care about this one

I maintain Storybook's Angular integration, which reads `documentation.json` to build the props table. This flag is why every Angular input in Storybook currently renders as required. Happy to adjust anything here to taste.

Refs #863
