### PR TITLE
fix(markdown): add anchor ids to generated headings

### DIFF
--- a/src/app/engines/markdown.engine.ts
+++ b/src/app/engines/markdown.engine.ts
@@ -20,6 +20,12 @@ export class MarkdownEngine {
 
     private markedInstance;
 
+    /**
+     * Tracks heading slugs seen in the markdown document currently being rendered,
+     * so duplicate headings get distinct anchor ids (reset per renderMarkdown call).
+     */
+    private headingSlugs: Map<string, number> = new Map();
+
     private static instance: MarkdownEngine;
     private constructor() {
         clearModuleCache('marked');
@@ -30,6 +36,11 @@ export class MarkdownEngine {
             gfm: true,
             breaks: false,
             renderer: {
+                heading(token) {
+                    const text = this.parser.parseInline(token.tokens);
+                    const id = self.uniqueSlug(self.slugify(token.text));
+                    return `<h${token.depth} id="${id}">${text}</h${token.depth}>\n`;
+                },
                 code(token) {
                     const language = token.lang || 'none';
                     const highlighted = self.escape(token.text);
@@ -166,7 +177,36 @@ export class MarkdownEngine {
     }
 
     private renderMarkdown(markdown: string): string {
+        this.headingSlugs = new Map();
         return this.markedInstance(this.normalizeBitbucketCommitLinks(markdown));
+    }
+
+    /**
+     * Converts heading text into a URL-friendly anchor id (GitHub-style slug).
+     */
+    private slugify(text: string): string {
+        return text
+            .toLowerCase()
+            .trim()
+            .replace(/<[^>]*>/g, '')
+            .replace(/[`*_~[\]()]/g, '')
+            .replace(/[^a-z0-9\s-]/g, '')
+            .trim()
+            .replace(/\s+/g, '-');
+    }
+
+    /**
+     * Ensures heading ids are unique within a single rendered document by
+     * suffixing repeats with -1, -2, etc, matching GitHub's anchor behavior.
+     */
+    private uniqueSlug(slug: string): string {
+        if (!this.headingSlugs.has(slug)) {
+            this.headingSlugs.set(slug, 0);
+            return slug;
+        }
+        const count = this.headingSlugs.get(slug) + 1;
+        this.headingSlugs.set(slug, count);
+        return `${slug}-${count}`;
     }
 
     private normalizeBitbucketCommitLinks(markdown: string): string {

--- a/test/src/engines/markdown.engine.spec.ts
+++ b/test/src/engines/markdown.engine.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import MarkdownEngine from '../../../src/app/engines/markdown.engine';
+import FileEngine from '../../../src/app/engines/file.engine';
+
+describe('Engines - MarkdownEngine', () => {
+    let getSyncStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        getSyncStub = sinon.stub(FileEngine, 'getSync');
+    });
+
+    afterEach(() => {
+        getSyncStub.restore();
+    });
+
+    describe('heading anchors', () => {
+        it('should add an id attribute derived from the heading text', () => {
+            getSyncStub.returns('# Getting Started\n\nSome content.');
+
+            const html = MarkdownEngine.getTraditionalMarkdownSync('doc');
+
+            expect(html).to.contain('<h1 id="getting-started">Getting Started</h1>');
+        });
+
+        it('should disambiguate duplicate headings within the same document', () => {
+            getSyncStub.returns('## Setup\n\nFirst.\n\n## Setup\n\nSecond.');
+
+            const html = MarkdownEngine.getTraditionalMarkdownSync('doc');
+
+            expect(html).to.contain('<h2 id="setup">Setup</h2>');
+            expect(html).to.contain('<h2 id="setup-1">Setup</h2>');
+        });
+
+        it('should not carry over slugs between separately rendered documents', () => {
+            getSyncStub.returns('# Intro\n');
+            const first = MarkdownEngine.getTraditionalMarkdownSync('doc-a');
+
+            getSyncStub.returns('# Intro\n');
+            const second = MarkdownEngine.getTraditionalMarkdownSync('doc-b');
+
+            expect(first).to.contain('<h1 id="intro">Intro</h1>');
+            expect(second).to.contain('<h1 id="intro">Intro</h1>');
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1495.

Problem: marked's default heading renderer doesn't add an id attribute to generated h1-h6 tags. Since the "Additional documentation" feature (--includes/summary.json) relies on anchor links (e.g. a hand-written table of contents linking to #some-heading) to jump to headings inside a rendered markdown page, those links silently do nothing since there's no matching id to scroll to.

Fix: MarkdownEngine already customizes the marked renderer for code/table/image. This adds a heading override that slugifies the heading text into a GitHub-style anchor (lowercase, punctuation stripped, spaces to hyphens); disambiguates repeated headings within the same document with a -1, -2, ... suffix, matching GitHub's own anchor behavior; and resets the seen-slugs map on every renderMarkdown call, so ids don't leak between separately rendered documents.

Testing: Added unit tests in test/src/engines/markdown.engine.spec.ts covering id generation, duplicate-heading disambiguation, and no state leaking across renders. Manually built docs for a fixture project with --includes pointing at test/fixtures/todomvc-ng2/additional-doc and confirmed the generated additional-documentation/*.html pages now contain e.g. <h1 id="introduction">Introduction</h1>, so a link like href="#introduction" now resolves correctly. npm run build succeeds and the existing code/table/image renderer overrides are untouched.