### PR TITLE
feat(schemas): add JSON schema for additional documentation summary.json

### DIFF
--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/compodoc/compodoc/blob/develop/schemas/summary.schema.json",
+    "title": "Compodoc additional documentation summary",
+    "description": "Describes the menu structure of markdown files provided via the --includes CLI flag. See https://compodoc.github.io/website/guides/includes.html",
+    "type": "array",
+    "items": {
+        "$ref": "#/definitions/entry"
+    },
+    "definitions": {
+        "entry": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["title", "file"],
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Menu label for this page."
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Path to the markdown file, relative to the --includes folder."
+                },
+                "children": {
+                    "type": "array",
+                    "description": "Nested pages, up to 5 levels of depth.",
+                    "items": {
+                        "$ref": "#/definitions/entry"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/src/schemas/summary.schema.spec.ts
+++ b/test/src/schemas/summary.schema.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Additional documentation summary.json schema', () => {
+    const schemaPath = path.resolve(__dirname, '../../../schemas/summary.schema.json');
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+    const entrySchema = schema.definitions.entry;
+
+    function validateEntry(node: any, errors: string[]): void {
+        entrySchema.required.forEach((key: string) => {
+            if (typeof node[key] !== 'string') {
+                errors.push(`missing or non-string "${key}"`);
+            }
+        });
+        if ('children' in node) {
+            if (!Array.isArray(node.children)) {
+                errors.push('"children" must be an array');
+            } else {
+                node.children.forEach((child: any) => validateEntry(child, errors));
+            }
+        }
+    }
+
+    it('should describe an array of entries requiring title and file', () => {
+        expect(schema.type).to.equal('array');
+        expect(entrySchema.required).to.include.members(['title', 'file']);
+    });
+
+    it('should validate the bundled --includes fixture', () => {
+        const fixturePath = path.resolve(
+            __dirname,
+            '../../fixtures/todomvc-ng2/additional-doc/summary.json'
+        );
+        const data = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+        const errors: string[] = [];
+        data.forEach((entry: any) => validateEntry(entry, errors));
+
+        expect(errors).to.deep.equal([]);
+    });
+
+    it('should flag an entry missing the required "file" property', () => {
+        const errors: string[] = [];
+        validateEntry({ title: 'Untitled' }, errors);
+
+        expect(errors).to.not.be.empty;
+    });
+});


### PR DESCRIPTION
Fixes #1414.

Problem: the "Additional documentation" feature (--includes flag) is driven by a hand-written summary.json file, but its shape (array of { title, file, children? } entries, up to 5 levels deep, per the traversal in Application.prepareExternalIncludes) is undocumented. As noted in #1414 and the related #577, editors like VS Code can't offer autocomplete or catch typos without a schema to associate with the file.

Change: adds schemas/summary.schema.json, a draft-07 JSON Schema describing that shape (title and file required strings, optional recursive children array). Since package.json has no "files" allowlist, this gets published as-is, so users can point their editor at it, e.g. via a json.schemas entry in .vscode/settings.json referencing ./node_modules/@compodoc/compodoc/schemas/summary.schema.json.

Testing: added test/src/schemas/summary.schema.spec.ts, which asserts the schema requires title/file, validates the real fixture at test/fixtures/todomvc-ng2/additional-doc/summary.json against it, and confirms an entry missing a required field is flagged. No application code changed.